### PR TITLE
Fix failing version compare for docker-ce

### DIFF
--- a/bin/check-docker.sh
+++ b/bin/check-docker.sh
@@ -18,7 +18,7 @@ function checkDockerVersion()
 
     verbose -n "${INFO}Checking docker version...${NC}"
 
-    if [ $(echo "${installedVersion}" | tr -d '.') -lt $(echo "${requiredMinimalVersion}" | tr -d '.') ]
+    if [ $(echo "${installedVersion}" | tr -d '.' | sed -E 's/[^0-9]+$//g') -lt $(echo "${requiredMinimalVersion}" | tr -d '.') ]
     then
         verbose ""
         error "${WARN}Docker version ${installedVersion} is not supported. Please update docker to at least ${requiredMinimalVersion}.${NC}"


### PR DESCRIPTION
If `docker version --format '{{.Server.Version}}'` outputs `18.06.2-ce` for example, the version compare fails because `tr` not strips the tailing `-ce`.