### PR TITLE
SC-1870: Adding TCP socket relay for Jenkins to be used for accessing…

### DIFF
--- a/generator/src/templates/deploy.bash.twig
+++ b/generator/src/templates/deploy.bash.twig
@@ -28,7 +28,6 @@ export COMPOSE_PROJECT_NAME={{ namespace | default('spryker') }}
 {% if _platform == 'windows' %}
 export COMPOSE_CONVERT_WINDOWS_PATHS=1
 {% endif %}
-export DOCKER_GID={% if _platform == 'linux' %}$(ls -n /var/run/docker.sock | awk '{print $4}'){% else %}0{% endif %}
 
 readonly PROGRESS_TYPE=${PROGRESS_TYPE:-tty}
 VERBOSE=${VERBOSE:-0}
@@ -519,7 +518,6 @@ function execDockerCompose()
     runArguments="${runArguments/${DEPLOYMENT_PATH}/${SPRYKER_REMOTE_DIR}}"
 
     DEPLOYMENT_PATH=${DEPLOYMENT_PATH} \
-    DOCKER_GID=${DOCKER_GID} \
     SPRYKER_LOG_DIRECTORY=${SPRYKER_LOG_DIRECTORY} \
     SPRYKER_DOCKER_PREFIX=${SPRYKER_DOCKER_PREFIX} \
     SPRYKER_DOCKER_TAG=${SPRYKER_DOCKER_TAG} \

--- a/generator/src/templates/service/jenkins.yml.twig
+++ b/generator/src/templates/service/jenkins.yml.twig
@@ -12,8 +12,19 @@
       SPRYKER_DOCKER_RUN_ARGUMENTS: ${SPRYKER_DOCKER_RUN_ARGUMENTS}
       SPRYKER_DOCKER_RUN_IMAGE: ${SPRYKER_DOCKER_RUN_IMAGE}
       SPRYKER_REMOTE_DIR: ${SPRYKER_REMOTE_DIR}
-    user: "1000:${DOCKER_GID}"
+      DOCKER_HOST: tcp://relay_{{ serviceName }}:2375
+    depends_on:
+      - relay_{{ serviceName }}
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/jenkins_home:rw
       - ./${DEPLOYMENT_PATH}/env:${SPRYKER_REMOTE_DIR}/env:ro
+
+  relay_{{ serviceName }}:
+    image: bpack/socat
+    command: TCP4-LISTEN:2375,fork,reuseaddr UNIX-CONNECT:/var/run/docker.sock
+    networks:
+      - private
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    expose:
+      - "2375"


### PR DESCRIPTION
… docker on the host

#### Overview

- Ticket: https://spryker.atlassian.net/browse/SC-1870

###### Optional

- Suite PR: https://github.com/spryker/suite-nonsplit/pull/2902

- Release Group: https://release.spryker.com/release-groups/view/1966

###### Change log

Adding TCP socket relay container for Jenkins to be used for accessing docker on the host in order to run jobs in separate containers on all platforms.