### PR TITLE
SC-2094: Using outdated docker compose leads to error

### DIFF
--- a/bin/boot-deployment.sh
+++ b/bin/boot-deployment.sh
@@ -9,6 +9,7 @@ pushd ${BASH_SOURCE%/*} > /dev/null
 
 ./require.sh docker
 ./check-docker.sh
+./check-docker-compose.sh
 popd > /dev/null
 
 export DOCKER_BUILDKIT=1

--- a/bin/check-docker-compose.sh
+++ b/bin/check-docker-compose.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+pushd ${BASH_SOURCE%/*} > /dev/null
+. ./constants.sh
+. ./console.sh
+
+VERBOSE=0 ./require.sh docker tr
+popd > /dev/null
+
+# ------------------
+function checkDockerComposeVersion()
+{
+    if [ "$(getPlatform)" == "linux" ]
+      then
+        local requiredMinimalVersion=${1:-'1.22.0'}
+        local installedDockerComposerVersion=$(which docker-compose > /dev/null; test $? -eq 0 && docker-compose version --short || echo 0;)
+
+        verbose -n "${INFO}Checking docker composer version...${NC}"
+
+        if [ $(echo "${installedDockerComposerVersion}" | tr -d '.' | sed -E 's/[^0-9]+$//g') -lt $(echo "${requiredMinimalVersion}" | tr -d '.') ]
+        then
+            verbose ""
+            error "${WARN}Docker Compose version ${installedDockerComposerVersion} is not supported. Please update Docker Compose to at least ${requiredMinimalVersion}.${NC}"
+            exit 1
+        fi
+    fi
+
+    verbose "[OK]"
+}
+
+checkDockerComposeVersion $@

--- a/bin/check-docker-compose.sh
+++ b/bin/check-docker-compose.sh
@@ -9,22 +9,20 @@ pushd ${BASH_SOURCE%/*} > /dev/null
 VERBOSE=0 ./require.sh docker tr
 popd > /dev/null
 
-# ------------------
 function checkDockerComposeVersion()
 {
-    if [ "$(getPlatform)" == "linux" ]
-      then
-        local requiredMinimalVersion=${1:-'1.22.0'}
-        local installedDockerComposerVersion=$(which docker-compose > /dev/null; test $? -eq 0 && docker-compose version --short || echo 0;)
+    [ ! "$(getPlatform)" == "linux" ] && exit 0;
 
-        verbose -n "${INFO}Checking docker composer version...${NC}"
+    local requiredMinimalVersion=${1:-'1.22.0'}
+    local installedDockerComposerVersion=$(which docker-compose > /dev/null; test $? -eq 0 && docker-compose version --short || echo 0;)
 
-        if [ $(echo "${installedDockerComposerVersion}" | tr -d '.' | sed -E 's/[^0-9]+$//g') -lt $(echo "${requiredMinimalVersion}" | tr -d '.') ]
-        then
-            verbose ""
-            error "${WARN}Docker Compose version ${installedDockerComposerVersion} is not supported. Please update Docker Compose to at least ${requiredMinimalVersion}.${NC}"
-            exit 1
-        fi
+    verbose -n "${INFO}Checking docker composer version...${NC}"
+
+    if [ $(echo "${installedDockerComposerVersion}" | tr -d '.' | sed -E 's/[^0-9]+$//g') -lt $(echo "${requiredMinimalVersion}" | tr -d '.') ]
+    then
+        verbose ""
+        error "${WARN}Docker Compose version ${installedDockerComposerVersion} is not supported. Please update Docker Compose to at least ${requiredMinimalVersion}.${NC}"
+        exit 1
     fi
 
     verbose "[OK]"

--- a/ci/check_boot.sh
+++ b/ci/check_boot.sh
@@ -29,6 +29,7 @@ deployment/default/env
 deployment/default/project.yml
 deployment/default/bin/boot-deployment.sh
 deployment/default/bin/check-docker.sh
+deployment/default/bin/check-docker-compose.sh
 deployment/default/bin/console.sh
 deployment/default/bin/constants.sh
 deployment/default/bin/database

--- a/generator/src/templates/deploy.bash.twig
+++ b/generator/src/templates/deploy.bash.twig
@@ -12,6 +12,7 @@ pushd ${BASH_SOURCE%/*} > /dev/null
 
 ./bin/require.sh docker docker-compose tr awk wc sed grep
 ./bin/check-docker.sh
+./bin/check-docker-compose.sh
 popd > /dev/null
 
 # Internal constants

--- a/generator/src/templates/env/common.env.twig
+++ b/generator/src/templates/env/common.env.twig
@@ -10,6 +10,3 @@ SPRYKER_LOG_DESTINATION=%LOG_TYPE%.log
 {% if project['docker']['debug']['enabled'] %}
 SPRYKER_DEBUG_ENABLED=1
 {% endif %}
-
-SPRYKER_REST_API_DOCUMENTATION_GENERATION_ENABLED=1
-

--- a/generator/src/templates/env/common.env.twig
+++ b/generator/src/templates/env/common.env.twig
@@ -10,3 +10,6 @@ SPRYKER_LOG_DESTINATION=%LOG_TYPE%.log
 {% if project['docker']['debug']['enabled'] %}
 SPRYKER_DEBUG_ENABLED=1
 {% endif %}
+
+SPRYKER_REST_API_DOCUMENTATION_GENERATION_ENABLED=1
+


### PR DESCRIPTION
#### Overview

- Ticket: https://spryker.atlassian.net/browse/SC-2094

###### Optional

- Release Group: https://release.spryker.com/release-groups/view/1961

###### Change log

- Introduced `Docker Compose` minimal version check.