### PR TITLE
fix: adds -r xarg parameter to stopCliContainer to allow sdk down command run correctly when in Development Mode.

### DIFF
--- a/generator/src/templates/deploy.bash.twig
+++ b/generator/src/templates/deploy.bash.twig
@@ -598,7 +598,7 @@ function stopCliContainer()
 {
   docker ps --filter "ancestor=${SPRYKER_DOCKER_PREFIX}_cli:${SPRYKER_DOCKER_TAG}" \
       --format "{{ '{{' }}.Names{{ '}}' }}" \
-      | xargs docker rm -f > /dev/null
+      | xargs -r docker rm -f > /dev/null
 }
 
 command=${1}


### PR DESCRIPTION
As stated in issue #51, when boostraped with `deploy.dev.yml` file, `sdk down` does not stop containers as it doesn't find any results from `docker ps --filter "ancestor=${SPRYKER_DOCKER_PREFIX}_cli:${SPRYKER_DOCKER_TAG}" --format "{{ '{{' }}.Names{{ '}}' }}"`. Since this is directly inputted to `xargs`, if it returns nothing it raises an error to the following command that is: `docker rm -f > /dev/null`.

Adding `-r` to `xarg` will not run the `docker rm` command, as stated in http://man7.org/linux/man-pages/man1/xargs.1.html: 

>        -r, --no-run-if-empty
>               If the standard input does not contain any nonblanks, do not
>               run the command.  Normally, the command is run once even if
>               there is no input.  This option is a GNU extension.

Though this argument is not available to OSX distributions.