### PR TITLE
SC-2085: "docker/sdk boot" lead to error if docker-machine are using on Linux env

### DIFF
--- a/bin/boot-deployment.sh
+++ b/bin/boot-deployment.sh
@@ -6,6 +6,7 @@ pushd ${BASH_SOURCE%/*} > /dev/null
 . ./constants.sh
 . ./console.sh
 . ./platform.sh
+. ./check-docker-machine.sh
 
 ./require.sh docker
 ./check-docker.sh
@@ -50,7 +51,8 @@ function bootDeployment()
 
     USER_UID=1000
     USER_GID=1000
-    [ "$(getPlatform)" == "linux" ] && USER_UID=$(id -u) && USER_GID=$(id -g)
+
+    [ "$(getPlatform)" == "linux" ] && ! $(isDockerMachineAvailable) && USER_UID=$(id -u) && USER_GID=$(id -g)
 
     verbose "${INFO}Running generator${NC}"
     docker run -i --rm \

--- a/bin/check-docker-machine.sh
+++ b/bin/check-docker-machine.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+pushd ${BASH_SOURCE%/*} > /dev/null
+. ./constants.sh
+popd > /dev/null
+
+function isDockerMachineAvailable()
+{
+    if [ ! -z $(echo ${DOCKER_MACHINE_NAME}) ];
+    then
+        return ${__TRUE};
+    fi
+
+    return ${__FALSE};
+}
+
+export -f isDockerMachineAvailable


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/SC-2085
RG: https://release.spryker.com/release-groups/view/2294

#### Release Notes

Updated boot functionality for providing correct `user_uid` and `user_gid` on Linux with docker-machine