### PR TITLE
SC-2840: Docker SDK: Multiple issues on Windows

### DIFF
--- a/bin/boot-deployment.sh
+++ b/bin/boot-deployment.sh
@@ -41,6 +41,7 @@ function bootDeployment()
     verbose "${INFO}Building generator${NC}"
     docker build -t spryker_docker_sdk \
         -f "${SOURCE_DIR}/generator/Dockerfile" \
+        --progress="${PROGRESS_TYPE:-tty}" \
         "${SOURCE_DIR}/generator"
 
     cp -rf "${SOURCE_DIR}/bin" "${DEPLOYMENT_DIR}/bin"

--- a/bin/build/mount.sh
+++ b/bin/build/mount.sh
@@ -30,7 +30,8 @@ function buildCode()
 
     [ "$1" = "${IF_NOT_PERFORMED}" ] && verbose "${INFO}Checking if anything should be built${NC}"
 
-    runApplicationBuild 'chmod 600 /data/config/Zed/*.key'
+    runApplicationBuild 'chmod 600 /data/config/Zed/*.key' || true
+    runApplicationBuild 'chmod +x vendor/bin/*' || true
 
     local vendorDirExist=$(runApplicationBuild '[ ! -f /data/vendor/bin/install ] && echo 0 || echo 1 | tail -n 1' | tr -d " \n\r")
     if [ "$1" != "${IF_NOT_PERFORMED}" ] || [ "${vendorDirExist}" == "0" ]; then
@@ -42,16 +43,6 @@ function buildCode()
     if [ "$1" != "${IF_NOT_PERFORMED}" ] || [ "${generatedDir}" == "0" ]; then
         verbose "${INFO}Running build${NC}"
         runApplicationBuild 'vendor/bin/install -r docker -s build -s build-development'
-    fi
-
-    if [ "$(getPlatform)" == 'windows' ];
-    then
-        # Fix the docker-sync permission issue on windows
-        local executableFile=$(runApplicationBuild '[ ! -x $(readlink -f vendor/bin/console) ] && echo 0 || echo 1 | tail -n 1' | tr -d " \n\r")
-        if [ "$1" != "${IF_NOT_PERFORMED}" ] || [ "${executableFile}" == "0" ];
-        then
-            runApplicationBuild 'chmod +x vendor/bin/*'
-        fi
     fi
 }
 

--- a/generator/src/templates/application-volumes.yml.twig
+++ b/generator/src/templates/application-volumes.yml.twig
@@ -9,6 +9,6 @@ x-volumes:
 {% if _mountMode == 'native' %}
     - ./:/data
 {% else %}
-    - ${SPRYKER_DOCKER_PREFIX}_${SPRYKER_DOCKER_TAG}_data_sync:/data
+    - ${SPRYKER_DOCKER_PREFIX}_${SPRYKER_DOCKER_TAG}_data_sync:/data:nocopy
 {% endif %}
 {% endif %}

--- a/generator/src/templates/deploy.bash.twig
+++ b/generator/src/templates/deploy.bash.twig
@@ -140,7 +140,6 @@ readonly USER_GID="1000"
 [ "$1" != 'help' ] && echo -e "*** ${WARN}DEVELOPMENT MODE${NC}"
 DOCKER_EXTRA_OPTIONS+=" -v ${DEPLOYMENT_DIR}/context/php/conf.d/opcache_dev.ini:/usr/local/etc/php/conf.d/opcache.ini:ro"
 DOCKER_EXTRA_OPTIONS+=" -v ${DEPLOYMENT_DIR}/context/php/php.ini:/usr/local/etc/php/php.ini:ro"
-DOCKER_EXTRA_OPTIONS+=" -v $(dirname ~/.composer/cache:/home/spryker/).composer/cache:rw"
 {% if _mountMode == 'native' %}
 DOCKER_EXTRA_OPTIONS+=" -v ${PROJECT_DIR}:/data -u ${USER_UID}:${USER_GID}"
 {% else %}

--- a/generator/src/templates/docker-sync.yml.twig
+++ b/generator/src/templates/docker-sync.yml.twig
@@ -1,18 +1,31 @@
 version: "2"
-
+{% set strategy = (_platform == 'macos') ? 'native_osx' : 'unison' %}
 options:
   verbose: true
+{% if docker['mount']['docker-sync']['image'] is not empty %}
+  {{ strategy }}_image: '{{ docker['mount']['docker-sync']['image'] }}'
+{% endif %}
 syncs:
   {{ namespace }}_{{ tag }}_data_sync:
     src: '.'
-    sync_strategy: {{ (_platform == 'macos') ? 'native_osx' : 'unison' }}
-    sync_excludes: ['.docker-sync', '/.git', '.idea', '.project', 'data/*/cache', '*.log', 'node_modules', 'docker', '.composer', '.npm']
+    sync_strategy: {{ strategy }}
+    sync_excludes:
+      - '.docker-sync'
+      - '/.git'
+      - '.idea'
+      - '.project'
+      - 'data/*/cache'
+      - '*.log'
+      - 'node_modules'
+      - 'docker'
+      - '.composer'
+      - '.npm'
 {%  if _platform == 'macos' %}
     host_disk_mount_mode: 'cached'
 {% endif %}
     sync_userid: '1000'
     sync_args:
-      - "-prefer newer"
+      - "-force newer"
 {% if _platform == 'windows' %}
       - "-perms=0"
 {% endif %}


### PR DESCRIPTION
- Ticket: https://spryker.atlassian.net/browse/SC-2840
- RG: https://release.spryker.com/release-groups/view/2441

### Bugfixes
- Allow using a custom image for docker-sync. 
- Unison's strategy changed from `prefer` to `force`. 
- Permission for binaries is now set before installation script.
- Mount mode for sync volume changed to `nocopy`
- The direct mount for the composer cache has been removed.