### PR TITLE
SC-2855: Support kibana 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ To start working with Spryker in Docker, follow [the link](https://documentation
 | mail_catcher  | mailhog  | 1.0  |
 | swagger  | swagger-ui  | v3.24  |
 | kibana  | kibana  | 5.6 |
+|   |   | 6.8 |

--- a/generator/src/templates/service/kibana/6.8/kibana.yml.twig
+++ b/generator/src/templates/service/kibana/6.8/kibana.yml.twig
@@ -1,0 +1,17 @@
+  {{ serviceName }}:
+    image: docker.elastic.co/kibana/kibana:6.8.6
+    networks:
+        - services
+        - private
+    healthcheck:
+        test: curl --cacert /usr/share/elasticsearch/config/certs/ca/ca.crt -s https://localhost:5601 >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi
+        interval: 30s
+        timeout: 10s
+        retries: 5
+    environment:
+        - NODE_OPTIONS=--max-old-space-size=5000
+    depends_on:
+        - search
+    volumes:
+        - {{ serviceName }}-{{ serviceData['engine'] }}-data:/usr/share/kibana/data:rw
+        - ./${DEPLOYMENT_PATH}/context/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml:ro


### PR DESCRIPTION
 Developer(s): @alexanderM91 

- Ticket: https://spryker.atlassian.net/browse/SC-2855

- Release Group: https://release.spryker.com/release-groups/view/2451

#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   DockerSdk         | minor                 |                       |

#### Release Notes

{none}

-----------------------------------------

#### Module DockerSDK

##### Change log

### Improvements

- Support Kibana version 6.