### PR TITLE
SC-2951: Clearing `opcache` under `root` in order to avoid permission…

### DIFF
--- a/images/base_app/Dockerfile
+++ b/images/base_app/Dockerfile
@@ -59,8 +59,6 @@ COPY --chown=spryker:spryker .* *.* LICENSE ${srcRoot}/
 ARG SPRYKER_COMPOSER_AUTOLOAD
 RUN composer dump-autoload ${SPRYKER_COMPOSER_AUTOLOAD}
 
-RUN rm -rf /var/run/opcache/*
-
 ARG DEPLOYMENT_PATH
 ENV DEPLOYMENT_PATH=${DEPLOYMENT_PATH}
 
@@ -72,6 +70,7 @@ COPY ${DEPLOYMENT_PATH}/context/php/conf.d/opcache.ini /usr/local/etc/php/conf.d
 
 # Run FPM as default command
 USER root
+RUN rm -rf /var/run/opcache/*
 RUN chown -R spryker:spryker /home/spryker
 
 CMD [ "php-fpm", "--nodaemonize" ]


### PR DESCRIPTION
- Ticket: https://spryker.atlassian.net/browse/SC-2951
- Release Group: https://release.spryker.com/release-groups/view/2500

##### Change Logs
### Bugfixes
- Fixed permission issue during the cleaning of `opcache`.