### PR TITLE
fix issue #92

### DIFF
--- a/generator/openssl/v3.ext
+++ b/generator/openssl/v3.ext
@@ -14,4 +14,5 @@ CN = Spryker
 [ v3_req ]
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
 subjectAltName = ${ENV::ALT_NAMES}


### PR DESCRIPTION
generate apple valid server certs by adding ExtendedKeyUsage (EKU) extension containing the id-kp-serverAuth OID

https://support.apple.com/en-us/HT210176
#92