### PR TITLE
 SC-3085: MariaDB v10.2-4 is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ To start working with Spryker in Docker, follow [the link](https://documentation
 | Service  | Engine  | Version(s)  |
 |---|---|---|
 | database  | postgres  | 9.6  |
-|   | mysql  | 5.7  |
+|   | mysql  | 5.7*  |
+|   | mysql  | mariadb-10.2  |
+|   | mysql  | mariadb-10.3  |
+|   | mysql  | mariadb-10.4  |
 | broker  | rabbitmq  | 3.7  |
 | session  | redis  | 5.0  |
 | key_value_store  | redis  | 5.0  |

--- a/generator/src/templates/service/mysql/mariadb-10.2/mysql.yml.twig
+++ b/generator/src/templates/service/mysql/mariadb-10.2/mysql.yml.twig
@@ -1,0 +1,16 @@
+  {{ serviceName }}:
+    image: mariadb:10.2
+    networks:
+      - private
+      - services
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "--silent"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    environment:
+      MYSQL_ROOT_PASSWORD: "{{ serviceData['root']['password'] }}"
+      LANG: C.UTF-8
+    volumes:
+      - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/lib/mysql:rw
+      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mysql.conf.d/my.cnf:ro

--- a/generator/src/templates/service/mysql/mariadb-10.3/mysql.yml.twig
+++ b/generator/src/templates/service/mysql/mariadb-10.3/mysql.yml.twig
@@ -1,0 +1,16 @@
+  {{ serviceName }}:
+    image: mariadb:10.3
+    networks:
+      - private
+      - services
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "--silent"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    environment:
+      MYSQL_ROOT_PASSWORD: "{{ serviceData['root']['password'] }}"
+      LANG: C.UTF-8
+    volumes:
+      - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/lib/mysql:rw
+      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mysql.conf.d/my.cnf:ro

--- a/generator/src/templates/service/mysql/mariadb-10.4/mysql.yml.twig
+++ b/generator/src/templates/service/mysql/mariadb-10.4/mysql.yml.twig
@@ -1,0 +1,16 @@
+  {{ serviceName }}:
+    image: mariadb:10.4
+    networks:
+      - private
+      - services
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "--silent"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    environment:
+      MYSQL_ROOT_PASSWORD: "{{ serviceData['root']['password'] }}"
+      LANG: C.UTF-8
+    volumes:
+      - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/lib/mysql:rw
+      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mysql.conf.d/my.cnf:ro


### PR DESCRIPTION
- Ticket: https://spryker.atlassian.net/browse/SC-3085
- RG: https://release.spryker.com/release-groups/view/2695

-----------------------------

###### Change log

### Improvements

- Introduced support for `MariaDB` versions: 10.2, 10.3, and 10.4.