### PR TITLE
SC-3131: Generate apple valid cert

### DIFF
--- a/generator/openssl/v3.ext
+++ b/generator/openssl/v3.ext
@@ -14,4 +14,5 @@ CN = Spryker
 [ v3_req ]
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
 subjectAltName = ${ENV::ALT_NAMES}


### PR DESCRIPTION
- Ticket: https://spryker.atlassian.net/browse/SC-3131
- RG: https://release.spryker.com/release-groups/view/2700


###### Change log

### Fixes

- Fixed generation of the apple valid server certs by adding ExtendedKeyUsage (EKU) extension containing the id-kp-serverAuth OID.