### PR TITLE
SC-3990: Make the port to fastcgi application configurable

### DIFF
--- a/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
+++ b/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
@@ -24,7 +24,7 @@ server {
     endpointData: endpointData,
     auth: endpointData['auth'] | default([]),
     storeServices: regions[groupData['region']]['stores'][endpointData['store']]['services'] | default([]),
-    upstream: "${SPRYKER_NGINX_CGI_HOST_" ~ (applicationName | upper) ~ "}" ~ ":9000",
+    upstream: "${SPRYKER_NGINX_CGI_" ~ (applicationName | upper) ~ "}",
     zedHost: _endpointMap[endpointData['store']]['zed'] | default(''),
     project: _context
 } %}

--- a/generator/src/templates/nginx/entrypoint.sh.twig
+++ b/generator/src/templates/nginx/entrypoint.sh.twig
@@ -3,7 +3,8 @@
 {% for groupData in groups %}
 {% for applicationName, applicationData in groupData['applications'] %}
 {% if applicationData['application'] != 'static' %}
-{% set envVariables = envVariables | merge(["\$SPRYKER_NGINX_CGI_HOST_" ~ (applicationName | upper)]) %}
+{% set envVariables = envVariables | merge(["\$SPRYKER_NGINX_CGI_" ~ (applicationName | upper)]) %}
+export SPRYKER_NGINX_CGI_{{ applicationName | upper}}=${SPRYKER_NGINX_CGI_{{ (applicationName | upper) }}:-"${SPRYKER_NGINX_CGI_HOST_{{ (applicationName | upper) }}}:9000"}
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
- Ticket: https://spryker.atlassian.net/browse/SC-4026
- RG: https://release.spryker.com/release-groups/view/2837

Create new environment variable which contains hostname and port
for the specific php application. For backwards compatibility the
value defaults to the "old" hostname environment variable with
the default fastcgi port 9000

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
