### PR TITLE
SC-4432: Added support for `:delegated` syncronization feature in Docker (MacOS)

### DIFF
--- a/.dockersyncignore.default
+++ b/.dockersyncignore.default
@@ -1,0 +1,13 @@
+.git*
+.idea
+.DS_Store
+/.nvmrc
+/.scrutinizer.yml
+/.travis.yml
+/newrelic.ini
+
+.unison*
+.docker-sync
+/docker
+
+node_modules

--- a/bin/sdk/assets/baked.sh
+++ b/bin/sdk/assets/baked.sh
@@ -26,8 +26,8 @@ function Assets::export() {
     fi
     docker run -i --rm "${userToRun[@]}" \
         -e PROJECT_DIR='/data' \
-        -v "${DEPLOYMENT_DIR}/bin:/data/standalone" \
-        -v "${projectDockerAssetsTmpDirectory}:/data${dockerAssetsTmpDirectory}" \
+        -v "${DEPLOYMENT_DIR}/bin:/data/standalone:consistent,rw" \
+        -v "${projectDockerAssetsTmpDirectory}:/data${dockerAssetsTmpDirectory}:consistent,rw" \
         --entrypoint='' \
         --name="${SPRYKER_DOCKER_PREFIX}_builder_assets" \
         "${builderAssetsImage}" \

--- a/bin/sdk/mount/delegated.sh
+++ b/bin/sdk/mount/delegated.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+require docker
+
+function sync() {
+
+    case $1 in
+        logs)
+            while :; do
+                curl -X GET --unix-socket ~/Library/Containers/com.docker.docker/Data/docker-api.sock http:/localhost/synchronize/state
+                sleep 1
+            done
+            ;;
+    esac
+
+    return "${TRUE}"
+}
+
+function Sync::Delegated::checkCompatibility() {
+
+    Console::verbose::start "Checking mount compatibility..."
+
+    if [ "$(Platform::getPlatform)" != 'macos' ]; then
+        Console::error "Delegated mount type is available only on MacOS. Please, change the mount type in deploy.yml."
+        exit 1
+    fi
+
+    if ! (command -v docker >/dev/null && docker >/dev/null 2>&1); then
+        Console::error "Docker is not running. Please, make sure Docker is installed and running."
+        exit 1
+    fi
+
+    if ! curl -X GET -f -I --unix-socket ~/Library/Containers/com.docker.docker/Data/docker-api.sock http:/localhost/synchronize/state >/dev/null 2>&1; then
+        Console::error "Your version of Docker Desktop does not support syncronization (https://docs.docker.com/docker-for-mac/mutagen). Please, update Docker or change the mount type in deploy.yml."
+        exit 1
+    fi
+
+    Console::end "[OK]"
+}
+
+Registry::addChecker 'Sync::Delegated::checkCompatibility'

--- a/generator/src/templates/application-volumes.yml.twig
+++ b/generator/src/templates/application-volumes.yml.twig
@@ -1,7 +1,7 @@
       - logs:${SPRYKER_LOG_DIRECTORY}:rw
 {% if _mountMode != 'baked' %}
-{% if _mountMode == 'native' %}
-      - ./:/data
+{% if _mountMode == 'native' or _mountMode == 'delegated' %}
+      - ./:/data:{{ _mountMode == 'delegated' ? 'delegated,' : '' }}rw
 {% else %}
       - ${SPRYKER_DOCKER_PREFIX}_${SPRYKER_DOCKER_TAG}_data_sync:/data:nocopy
 {% endif %}

--- a/generator/src/templates/docker-compose.test.yml.twig
+++ b/generator/src/templates/docker-compose.test.yml.twig
@@ -32,4 +32,4 @@ services:
     image: nginx:alpine
     user: "0:0"
     volumes:
-      - ./${DEPLOYMENT_PATH}/context/nginx/dummy/scheduler.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./${DEPLOYMENT_PATH}/context/nginx/dummy/scheduler.conf:/etc/nginx/conf.d/default.conf:consistent,ro

--- a/generator/src/templates/docker-compose.yml.twig
+++ b/generator/src/templates/docker-compose.yml.twig
@@ -18,7 +18,7 @@ services:
       'spryker.project': ${SPRYKER_DOCKER_PREFIX}:${SPRYKER_DOCKER_TAG}
     volumes:
       - cli_history:/home/spryker/history:rw
-      - ./${DEPLOYMENT_PATH}/env/cli:/home/spryker/env:ro
+      - ./${DEPLOYMENT_PATH}/env/cli:/home/spryker/env:consistent,ro
 {% include "application-volumes.yml.twig" with _context %}
     tty: true
     environment:
@@ -64,8 +64,8 @@ services:
 {% endfor %}
 {% if _mountMode != 'baked' %}
     volumes:
-{% if _mountMode == 'native' %}
-      - ./public:/data/public:ro
+{% if _mountMode == 'native' or _mountMode == 'delegated' %}
+      - ./public:/data/public:{{ _mountMode == 'delegated' ? 'delegated,' : '' }}ro
 {% else %}
       - ${SPRYKER_DOCKER_PREFIX}_${SPRYKER_DOCKER_TAG}_data_sync:/data
 {% endif %}
@@ -134,7 +134,7 @@ volumes:
     external: false
   cli_history:
     external: false
-{% if  _mountMode != 'baked' and _mountMode != 'native' %}
+{% if  _mountMode != 'baked' and _mountMode != 'native' and _mountMode != 'delegated' %}
   {{ namespace }}_{{ tag }}_data_sync:
     external: true
 {% endif %}

--- a/generator/src/templates/service/elastic/5.6/elastic.yml.twig
+++ b/generator/src/templates/service/elastic/5.6/elastic.yml.twig
@@ -15,4 +15,4 @@
       ES_JAVA_OPTS: "-Xms384m -Xmx512m"
     volumes:
       - {{ serviceName }}-{{ serviceData['engine'] }}-data:/usr/share/elasticsearch/data:rw
-      - ./${DEPLOYMENT_PATH}/context/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+      - ./${DEPLOYMENT_PATH}/context/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:consistent,ro

--- a/generator/src/templates/service/elastic/6.8/elastic.yml.twig
+++ b/generator/src/templates/service/elastic/6.8/elastic.yml.twig
@@ -19,4 +19,4 @@
         ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     volumes:
         - {{ serviceName }}-{{ serviceData['engine'] }}-data:/usr/share/elasticsearch/data:rw
-        - ./${DEPLOYMENT_PATH}/context/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+        - ./${DEPLOYMENT_PATH}/context/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:consistent,ro

--- a/generator/src/templates/service/elastic/7.6/elastic.yml.twig
+++ b/generator/src/templates/service/elastic/7.6/elastic.yml.twig
@@ -19,4 +19,4 @@
         ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     volumes:
         - {{ serviceName }}-{{ serviceData['engine'] }}-data:/usr/share/elasticsearch/data:rw
-        - ./${DEPLOYMENT_PATH}/context/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
+        - ./${DEPLOYMENT_PATH}/context/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:consistent,ro

--- a/generator/src/templates/service/jenkins/2.176/jenkins.yml.twig
+++ b/generator/src/templates/service/jenkins/2.176/jenkins.yml.twig
@@ -15,4 +15,4 @@
       SPRYKER_CLI_CONTAINER: "${COMPOSE_PROJECT_NAME}_cli_1"
     volumes:
       - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/jenkins_home:rw
-      - ${DEPLOYMENT_PATH}/context/jenkins/spryker.sh:/usr/bin/spryker.sh:rw
+      - ${DEPLOYMENT_PATH}/context/jenkins/spryker.sh:/usr/bin/spryker.sh:consistent,ro

--- a/generator/src/templates/service/kibana/6.8/kibana.yml.twig
+++ b/generator/src/templates/service/kibana/6.8/kibana.yml.twig
@@ -17,4 +17,4 @@
         - search
     volumes:
         - {{ serviceName }}-{{ serviceData['engine'] }}-data:/usr/share/kibana/data:rw
-        - ./${DEPLOYMENT_PATH}/context/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml:ro
+        - ./${DEPLOYMENT_PATH}/context/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml:consistent,ro

--- a/generator/src/templates/service/mailhog/1.0/mailhog.yml.twig
+++ b/generator/src/templates/service/mailhog/1.0/mailhog.yml.twig
@@ -14,4 +14,4 @@
       timeout: 5s
       retries: 5
     volumes:
-      - {{ serviceName }}-{{ serviceData['engine'] }}-data:/maildir
+      - {{ serviceName }}-{{ serviceData['engine'] }}-data:/maildir:rw

--- a/generator/src/templates/service/mysql/5.7/mysql.yml.twig
+++ b/generator/src/templates/service/mysql/5.7/mysql.yml.twig
@@ -16,4 +16,4 @@
       LANG: C.UTF-8
     volumes:
       - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/lib/mysql:rw
-      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/my.cnf:ro
+      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/my.cnf:consistent,ro

--- a/generator/src/templates/service/mysql/mariadb-10.2/mysql.yml.twig
+++ b/generator/src/templates/service/mysql/mariadb-10.2/mysql.yml.twig
@@ -16,4 +16,4 @@
       LANG: C.UTF-8
     volumes:
       - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/lib/mysql:rw
-      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mysql.conf.d/my.cnf:ro
+      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mysql.conf.d/my.cnf:consistent,ro

--- a/generator/src/templates/service/mysql/mariadb-10.3/mysql.yml.twig
+++ b/generator/src/templates/service/mysql/mariadb-10.3/mysql.yml.twig
@@ -16,4 +16,4 @@
       LANG: C.UTF-8
     volumes:
       - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/lib/mysql:rw
-      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mysql.conf.d/my.cnf:ro
+      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mysql.conf.d/my.cnf:consistent,ro

--- a/generator/src/templates/service/mysql/mariadb-10.4/mysql.yml.twig
+++ b/generator/src/templates/service/mysql/mariadb-10.4/mysql.yml.twig
@@ -16,4 +16,4 @@
       LANG: C.UTF-8
     volumes:
       - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/lib/mysql:rw
-      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mysql.conf.d/my.cnf:ro
+      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mysql.conf.d/my.cnf:consistent,ro

--- a/generator/src/templates/service/redis/5.0/redis.yml.twig
+++ b/generator/src/templates/service/redis/5.0/redis.yml.twig
@@ -13,4 +13,4 @@
         timeout: 5s
         retries: 5
     volumes:
-      - {{ serviceName }}-{{ serviceData['engine'] }}-data:/data
+      - {{ serviceName }}-{{ serviceData['engine'] }}-data:/data:rw


### PR DESCRIPTION
## PR Description

Ticket: https://spryker.atlassian.net/browse/SC-4432

Forward compatibility.
Based on https://docs.docker.com/docker-for-mac/mutagen/.
Currently works only on Docker Edge.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md

## How to try it

FOR MACOS USERS ONLY
It is confirmed it does work properly with Docker Desktop for Mac 2.3.4.0 (46980) Edge.

1. Stop Docker, download and install this one:
https://desktop.docker.com/mac/edge/46980/Docker.dmg
2. Checkout `docker` to `feature/sc-4432/master-support-docker-delegated`
3. Copy deploy.dev.yml -> deploy.local.yml
4. Adjust deploy.local.yml `mount` section to the following:
```
 mount:
        delegated:
```
5. `docker/sdk boot && docker/sdk up --build --assets`
6. Just make your routines
