### PR TITLE
SC-4432: Adding support of mutagen.io as file sync solution for Mac/W…

### DIFF
--- a/.dockersyncignore.default
+++ b/.dockersyncignore.default
@@ -1,0 +1,13 @@
+.git*
+.idea
+.DS_Store
+/.nvmrc
+/.scrutinizer.yml
+/.travis.yml
+/newrelic.ini
+
+.unison*
+.docker-sync
+/docker
+
+node_modules

--- a/bin/command/install/bootstrap.sh
+++ b/bin/command/install/bootstrap.sh
@@ -90,6 +90,7 @@ function Command::bootstrap() {
     cp -rf "${SOURCE_DIR}/bin/standalone" "${tmpDeploymentDir}/context/cli"
     cp -rf "${SOURCE_DIR}/images" "${tmpDeploymentDir}/images"
     cp "${projectYaml}" "${tmpDeploymentDir}/project.yml"
+    cp "$([ -f "./.dockersyncignore" ] && echo './.dockersyncignore' || echo "${SOURCE_DIR}/.dockersyncignore.default")" "${tmpDeploymentDir}/.dockersyncignore"
     if [ -f ".known_hosts" ]; then
         cp ".known_hosts" "${tmpDeploymentDir}/"
     fi
@@ -108,15 +109,6 @@ function Command::bootstrap() {
         -e VERBOSE="${VERBOSE}" \
         -v "${tmpDeploymentDir}":/data/deployment:rw \
         spryker_docker_sdk
-
-    # Just in case of docker volumes caching
-    local counter=1
-    while :; do
-        [ -f "${tmpDeploymentDir}/deploy" ] && break
-        [ "${counter}" -ge 20 ] && Console::error "Could not wait for sync anymore." && exit 1
-        counter=$((counter + 1))
-        sleep 1
-    done
 
     chmod +x "${tmpDeploymentDir}/deploy"
 

--- a/bin/command/install/clean.sh
+++ b/bin/command/install/clean.sh
@@ -6,7 +6,7 @@ Registry::Help::command -c "clean" "Stops all Spryker containers and remove imag
 
 function Command::clean() {
     Compose::cleanEverything
-    sync clean
+    sync clean # TODO deprecated, use Registry::Flow::addAfterDown in mounts
     Images::destroy
 
     return "${TRUE}"

--- a/bin/command/internal/prune.sh
+++ b/bin/command/internal/prune.sh
@@ -4,7 +4,7 @@ Registry::addCommand "prune" "Command::prune"
 
 function Command::prune() {
     Compose::down
-    sync clean
+    sync clean # TODO deprecated, use Registry::Flow::addAfterDown in mounts
     Console::error "This will delete ALL docker images and volumes on the host."
     docker image prune
     docker volume prune

--- a/bin/command/internal/sync.sh
+++ b/bin/command/internal/sync.sh
@@ -13,7 +13,8 @@ function Command::sync() {
             sync start
             ;;
         logs|log)
-            sync logs
+            sync logs # TODO deprecated, use Mount::logs instead
+            Mount::logs "${@}"
             ;;
         *)
             Console::error "Unknown command ${INFO}${command}${WARN} is occurred."

--- a/bin/command/internal/trouble.sh
+++ b/bin/command/internal/trouble.sh
@@ -4,7 +4,7 @@ Registry::addCommand "trouble" "Command::trouble"
 
 function Command::trouble() {
     Compose::down
-    sync clean
+    sync clean # TODO deprecated, use Registry::Flow::addAfterDown in mounts
 
     return "${TRUE}"
 }

--- a/bin/lib/string.sh
+++ b/bin/lib/string.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function String::trimWhitespaces() {
-    echo "${*}" | tr -d " /n/r"
+    echo -n "${*}" | tr -d " /n/r"
 }
 
 function String::removeColors() {

--- a/bin/lib/version.sh
+++ b/bin/lib/version.sh
@@ -2,7 +2,9 @@
 
 require awk
 
+import lib/string.sh
+
 function Version::parse {
-    local version="$(echo -n "$@" | awk -F. '{ printf("%d%03d%03d%03d", $1,$2,$3,$4); }')"
+    local version="$(String::trimWhitespaces "$@" | awk -F. '{ printf("%d%03d%03d%03d", $1,$2,$3,$4); }')"
     echo $((version + 0))
 }

--- a/bin/registry/flow.sh
+++ b/bin/registry/flow.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 declare -a FLOW_BOOT
+declare -a FLOW_BEFORE_UP
 declare -a FLOW_BEFORE_RUN
+declare -a FLOW_AFTER_CLI_READY
+declare -a FLOW_AFTER_RUN
+declare -a FLOW_AFTER_UP
+declare -a FLOW_AFTER_STOP
 declare -a FLOW_AFTER_DOWN
 
 function Registry::Flow::addBoot() {
@@ -23,6 +28,25 @@ function Registry::Flow::runBoot() {
     return "${TRUE}"
 }
 
+function Registry::Flow::addBeforeUp() {
+    local func=$1
+
+    FLOW_BEFORE_UP+=("${func}")
+
+    return "${TRUE}"
+}
+
+function Registry::Flow::runBeforeUp() {
+
+    local func=''
+
+    for func in "${FLOW_BEFORE_UP[@]}"; do
+        ${func} "${@}"
+    done
+
+    return "${TRUE}"
+}
+
 function Registry::Flow::addBeforeRun() {
     local func=$1
 
@@ -36,6 +60,82 @@ function Registry::Flow::runBeforeRun() {
     local func=''
 
     for func in "${FLOW_BEFORE_RUN[@]}"; do
+        ${func} "${@}"
+    done
+
+    return "${TRUE}"
+}
+
+function Registry::Flow::addAfterRun() {
+    local func=$1
+
+    FLOW_AFTER_RUN+=("${func}")
+
+    return "${TRUE}"
+}
+
+function Registry::Flow::runAfterRun() {
+
+    local func=''
+
+    for func in "${FLOW_AFTER_RUN[@]}"; do
+        ${func} "${@}"
+    done
+
+    return "${TRUE}"
+}
+
+function Registry::Flow::addAfterCliReady() {
+    local func=$1
+
+    FLOW_AFTER_CLI_READY+=("${func}")
+
+    return "${TRUE}"
+}
+
+function Registry::Flow::runAfterCliReady() {
+
+    local func=''
+
+    for func in "${FLOW_AFTER_CLI_READY[@]}"; do
+        ${func} "${@}"
+    done
+
+    return "${TRUE}"
+}
+
+function Registry::Flow::addAfterUp() {
+    local func=$1
+
+    FLOW_AFTER_UP+=("${func}")
+
+    return "${TRUE}"
+}
+
+function Registry::Flow::runAfterUp() {
+
+    local func=''
+
+    for func in "${FLOW_AFTER_UP[@]}"; do
+        ${func} "${@}"
+    done
+
+    return "${TRUE}"
+}
+
+function Registry::Flow::addAfterStop() {
+    local func=$1
+
+    FLOW_AFTER_STOP+=("${func}")
+
+    return "${TRUE}"
+}
+
+function Registry::Flow::runAfterStop() {
+
+    local func=''
+
+    for func in "${FLOW_AFTER_STOP[@]}"; do
         ${func} "${@}"
     done
 

--- a/bin/sdk/compose.sh
+++ b/bin/sdk/compose.sh
@@ -37,6 +37,7 @@ function Compose::ensureCliRunning() {
     local isCliRunning=$(docker ps --filter 'status=running' --filter "ancestor=${SPRYKER_DOCKER_PREFIX}_run_cli:${SPRYKER_DOCKER_TAG}" --filter "name=${SPRYKER_DOCKER_PREFIX}_cli_*" --format "{{.Names}}")
     if [ -z "${isCliRunning}" ]; then
         Compose::run --no-deps cli
+        Registry::Flow::runAfterCliReady
     fi
 }
 
@@ -78,7 +79,7 @@ function Compose::command() {
     local -a composeFiles=()
     IFS=' ' read -r -a composeFiles <<< "$(Compose::getComposeFiles)"
 
-    docker-compose \
+    ${DOCKER_COMPOSE_SUBSTITUTE:-'docker-compose'} \
         --project-directory "${PROJECT_DIR}" \
         --project-name "${SPRYKER_DOCKER_PREFIX}" \
         "${composeFiles[@]}" \
@@ -118,12 +119,17 @@ function Compose::up() {
         esac
     done
 
+    Registry::Flow::runBeforeUp
+
     Images::buildApplication ${noCache} ${doBuild}
     Codebase::build ${noCache} ${doBuild}
     Assets::build ${noCache} ${doAssets}
     Images::buildFrontend ${noCache} ${doBuild}
     Compose::run --build
     Compose::command restart frontend gateway
+
+    Registry::Flow::runAfterUp
+
     Data::load ${noCache} ${doData}
     Service::Scheduler::start ${noCache} ${doJobs}
 }
@@ -134,6 +140,9 @@ function Compose::run() {
     Console::verbose "${INFO}Running Spryker containers${NC}"
     sync start
     Compose::command up -d --remove-orphans "${@}"
+
+    # Note: Compose::run can be used for running only one container, e.g. CLI.
+    Registry::Flow::runAfterRun
 }
 
 function Compose::ps() {
@@ -149,20 +158,24 @@ function Compose::restart() {
 function Compose::stop() {
     Console::verbose "${INFO}Stopping all containers${NC}"
     Compose::command stop
+    Registry::Flow::runAfterStop
 }
 
 function Compose::down() {
     Console::verbose "${INFO}Stopping and removing all containers${NC}"
     Compose::command down --remove-orphans
     sync stop
+    Registry::Flow::runAfterDown
 }
 
 function Compose::cleanVolumes() {
     Console::verbose "${INFO}Stopping and removing all Spryker containers and volumes${NC}"
     Compose::command down -v --remove-orphans
+    Registry::Flow::runAfterDown
 }
 
 function Compose::cleanEverything() {
     Console::verbose "${INFO}Stopping and removing all Spryker containers and volumes${NC}"
     Compose::command down -v --remove-orphans --rmi all
+    Registry::Flow::runAfterDown
 }

--- a/bin/sdk/mount/baked.sh
+++ b/bin/sdk/mount/baked.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-function sync() {
+function Mount::logs() {
+    Console::error "This mount mode does not support logging."
+    exit 1
+}
 
-    case $1 in
-        logs)
-            Console::error "This mount mode does not support logging."
-            exit 1
-            ;;
-    esac
+function sync() {
+    # @deprecated
 
     return "${TRUE}"
 }

--- a/bin/sdk/mount/docker-sync.sh
+++ b/bin/sdk/mount/docker-sync.sh
@@ -11,7 +11,7 @@ function sync() {
     case "${command}" in
         create)
             Console::verbose "${INFO}Creating 'data-sync' volume${NC}"
-            docker volume create --name="${syncVolume}"
+            docker volume create --name="${syncVolume}" >/dev/null
             ;;
 
         recreate)

--- a/bin/sdk/mount/mutagen.sh
+++ b/bin/sdk/mount/mutagen.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+require docker grep awk
+
+import lib/version.sh
+import lib/string.sh
+
+# shellcheck disable=SC2034
+DOCKER_COMPOSE_SUBSTITUTE='mutagen compose'
+
+function Mount::logs() {
+    mutagen sync monitor "${SPRYKER_SYNC_SESSION_NAME}"
+}
+
+function sync() {
+    # @deprecated
+
+    return "${TRUE}"
+}
+
+function Mount::Mutagen::beforeUp() {
+    local sessionStatus
+
+    # Let's clean volume on cold start when containers are not running to avoid offline conflicts
+    # The volume will not be deleted if any app container is running.
+    docker volume rm "${SPRYKER_SYNC_VOLUME}" >/dev/null 2>&1 || true
+
+    # Clean content of the sync volume if the sync session is terminated or halted.
+    sessionStatus=$(mutagen sync list "${SPRYKER_SYNC_SESSION_NAME}" 2>/dev/null | grep 'Status:' | awk '{print $2}' || echo '')
+    if [ -z "${sessionStatus}" ] || [ "${sessionStatus}" == 'Halted' ]; then
+        Console::verbose::start "${INFO}Cleaning previous synced files${NC}"
+        mutagen sync terminate "${SPRYKER_SYNC_SESSION_NAME}" >/dev/null 2>&1 || true
+        docker run -i --rm -v "${SPRYKER_SYNC_VOLUME}:/data" busybox find /data/ ! -path /data/ -delete >/dev/null 2>&1 || true
+        Console::end "[OK]"
+    fi
+}
+
+# This is necessary due to https://github.com/mutagen-io/mutagen/issues/224
+function Mount::Mutagen::beforeRun() {
+    Console::verbose::start "${INFO}Creating file syncronization volume${NC}"
+    docker volume create --name="${SPRYKER_SYNC_VOLUME}" >/dev/null
+    docker run -it --rm -v "${SPRYKER_SYNC_VOLUME}:/data" busybox chmod 777 /data >/dev/null 2>&1
+    Console::end "[OK]"
+}
+
+# This is necessary due to https://github.com/mutagen-io/mutagen/issues/225
+function Mount::Mutagen::afterCliReady() {
+    Console::verbose "${INFO}Flushing file syncronization${NC}"
+    mutagen sync flush "${SPRYKER_SYNC_SESSION_NAME}"
+}
+
+function Mount::Mutagen::afterDown() {
+    Console::verbose "${INFO}Pruning file syncronization${NC}"
+    docker volume rm "${SPRYKER_SYNC_VOLUME}" >/dev/null 2>&1 || true
+    mutagen sync terminate "${SPRYKER_SYNC_SESSION_NAME}" >/dev/null 2>&1 || true
+}
+
+function Mount::Mutagen::install() {
+
+    local installedVersion
+    local requiredMinimalVersion='0.12.0'
+
+    installedVersion=$(String::trimWhitespaces "$(
+        command -v mutagen >/dev/null 2>&1
+        # shellcheck disable=SC2015
+        test $? -eq 0 && mutagen version
+    )")
+
+    if [ -z "${installedVersion}" ]; then
+        Console::error "Mutagen.io binary is not available. Please, install Mutagen.io. Minimum required version is: ${requiredMinimalVersion}."
+
+        if [ "${_PLATFORM}" == 'macos' ]; then
+            echo -n "brew install mutagen-io/mutagen/mutagen-beta"
+        fi
+
+        return "${FALSE}"
+    fi
+
+    if [ "$(Version::parse "${installedVersion}")" -lt "$(Version::parse "${requiredMinimalVersion}")" ]; then
+        Console::error "Mutagen.io version ${installedVersion} is not supported. Please, update Mutagen.io to at least ${requiredMinimalVersion}."
+
+        if [ "${_PLATFORM}" == 'macos' ]; then
+            echo -n "brew list | grep mutagen | xargs ${XARGS_NO_RUN_IF_EMPTY} brew remove && brew install mutagen-io/mutagen/mutagen-beta"
+        fi
+        return "${FALSE}"
+    fi
+
+    return "${TRUE}"
+}
+
+Registry::Flow::addBeforeUp 'Mount::Mutagen::beforeUp'
+Registry::Flow::addBeforeRun 'Mount::Mutagen::beforeRun'
+Registry::Flow::addAfterCliReady 'Mount::Mutagen::afterCliReady'
+Registry::Flow::addAfterDown 'Mount::Mutagen::afterDown'
+Registry::addInstaller 'Mount::Mutagen::install'

--- a/bin/sdk/mount/native.sh
+++ b/bin/sdk/mount/native.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-function sync() {
+function Mount::logs() {
+    Console::error "This mount mode does not support logging."
+    exit 1
+}
 
-    case $1 in
-        logs)
-            Console::error "This mount mode does not support logging."
-            exit 1
-            ;;
-    esac
+function sync() {
+    # @deprecated
 
     return "${TRUE}"
 }

--- a/bin/sdk/mount/nfs.sh
+++ b/bin/sdk/mount/nfs.sh
@@ -5,20 +5,18 @@ require docker
 import environment/get-real-project-path.sh
 
 function sync() {
-    local volumeName="${SPRYKER_DOCKER_PREFIX}_${SPRYKER_DOCKER_TAG}_data_sync"
-
     case $1 in
         create)
             Console::verbose "${INFO}Creating 'data-sync' volume${NC}"
             docker volume create --driver local --opt type=nfs \
                 --opt o=addr=host.docker.internal,rw,nolock,fsc,ac,cto,hard,noatime,nointr,nfsvers=3 \
                 --opt device=":$(Environment::getRealProjectPath)" \
-                --name="${volumeName}" \
+                --name="${SPRYKER_SYNC_VOLUME}" \
                 >/dev/null
             ;;
 
         clean)
-            docker volume rm "${volumeName}" >/dev/null 2>&1 || true
+            docker volume rm "${SPRYKER_SYNC_VOLUME}" >/dev/null 2>&1 || true
             ;;
 
         stop) ;;

--- a/generator/index.php
+++ b/generator/index.php
@@ -56,6 +56,8 @@ $projectData['_defaultDeploymentDir'] = $defaultDeploymentDir;
 $projectData['tag'] = $projectData['tag'] ?? uniqid();
 $projectData['_platform'] = $platform;
 $mountMode = $projectData['_mountMode'] = retrieveMountMode($projectData, $platform);
+$projectData['_syncIgnore'] = buildSyncIgnore($deploymentDir);
+$projectData['_syncSessionName'] = preg_replace('/[^-a-zA-Z0-9]/', '-', $projectData['namespace'] . '-' . $projectData['tag'] . '-codebase');
 $projectData['_isDevelopment'] = $mountMode !== 'baked';
 $projectData['_fileMode'] = $mountMode === 'baked' ? 'baked' : 'mount';
 $projectData['_ports'] = retrieveUniquePorts($projectData);
@@ -627,6 +629,29 @@ function getStoreSpecific(array $projectData): array
     }
 
     return $storeSpecific;
+}
+
+/**
+ * @param string $deploymentDir
+ *
+ * @return string[]
+ */
+function buildSyncIgnore(string $deploymentDir): array
+{
+    $sourceFilePath = $deploymentDir . DS . '.dockersyncignore';
+
+    if (!file_exists($sourceFilePath)) {
+        return [];
+    }
+
+    $sourceContent = (string) file_get_contents($sourceFilePath);
+
+    $rules = array();
+    preg_match_all('/([^\n#]+)?.*$/im', $sourceContent, $rules);
+
+    return array_map(static function ($element) {
+        return addslashes(trim($element));
+    }, array_filter($rules[1]));
 }
 
 /**

--- a/generator/src/templates/deploy.bash.twig
+++ b/generator/src/templates/deploy.bash.twig
@@ -5,6 +5,9 @@ set -e
 
 SELF_SCRIPT=${SELF_SCRIPT:-$0}
 
+# Overridable
+DOCKER_COMPOSE_SUBSTITUTE='docker-compose'
+
 pushd "${BASH_SOURCE%/*}" >/dev/null
 . ./bin/framework.sh
 popd >/dev/null
@@ -118,6 +121,8 @@ readonly SPRYKER_DB_ENGINE="{{ services['database']['engine'] == 'mysql' ? 'mysq
 readonly SPRYKER_STORES=({{ regions | map((regionData, region) => "'local REGION=" ~ '"' ~ region ~ '"' ~ "; local STORES=(" ~ (regionData['stores'] | keys | join(' ')) ~ ")'") | join(' ') | raw }})
 readonly SPRYKER_DEFAULT_STORE={{ (regions | first)['stores'] | keys | first }}
 readonly SPRYKER_FILE_MODE="{{ _fileMode }}"
+readonly SPRYKER_SYNC_SESSION_NAME="{{ _syncSessionName }}"
+readonly SPRYKER_SYNC_VOLUME="${SPRYKER_DOCKER_PREFIX}_${SPRYKER_DOCKER_TAG}_data_sync"
 readonly DOCKER_COMPOSE_FILES_EXTRA="{{ docker['compose']['yamls'] | default([]) | join(' ') }}"
 readonly SPRYKER_DASHBOARD_ENDPOINT="{{ _dashboardEndpoint }}"
 readonly KNOWN_HOSTS="{{ _knownHosts | default("") }}"

--- a/generator/src/templates/docker-compose.yml.twig
+++ b/generator/src/templates/docker-compose.yml.twig
@@ -139,6 +139,31 @@ volumes:
     external: true
 {% endif %}
 
+{% if  _mountMode == 'mutagen' %}
+x-mutagen:
+  sync:
+    defaults:
+      symlink:
+        mode: posix-raw
+      ignore:
+        paths:
+{% for rule in _syncIgnore %}
+          - '{{ rule | raw }}'
+{% endfor %}
+      permissions:
+        defaultFileMode: 0666
+        defaultDirectoryMode: 0777
+
+    {{ _syncSessionName }}:
+      alpha: ./
+      beta: volume://{{ namespace }}_{{ tag }}_data_sync
+      mode: two-way-resolved
+      configurationBeta:
+        permissions:
+          defaultOwner: id:1000
+          defaultGroup: id:1000
+
+{% endif %}
 networks:
   public:
   private:


### PR DESCRIPTION
## PR Description

Ticket: https://spryker.atlassian.net/browse/SC-4432

Forward compatibility.
Based on https://docs.docker.com/docker-for-mac/mutagen/.
Currently works only on Docker Edge.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md

## How to try it

FOR MACOS USERS ONLY at the moment
It is confirmed it does work properly with Docker Desktop for Mac 2.3.4.0 (46980) Edge.

1. Make sure you use Stable version of Docker Desktop for Mac (e.g. 2.3.0.4).
2. Checkout `docker` to `feature/sc-4432/master-mutagen`
3. Copy deploy.dev.yml -> deploy.local.yml
4. Adjust deploy.local.yml `mount` section to the following:
```
 mount:
        mutagen:
```
5. `docker/sdk boot && docker/sdk up --build --assets`
6. Just make your routines
