### PR TITLE
SC-4807: Added possibility to set CORS allow origin value via deploy.yml

### DIFF
--- a/generator/index.php
+++ b/generator/index.php
@@ -20,6 +20,12 @@ $loaders = new ChainLoader([
     new FilesystemLoader($deploymentDir),
 ]);
 $twig = new Environment($loaders);
+$nginxVarEncoder = new class() {
+    public function encode($value)
+    {
+        return str_replace([' ', '"', '{', '}'], ['\ ', '\"', '\{', '\}'], (string)$value);
+    }
+};
 $envVarEncoder = new class() {
     private $isActive = false;
 
@@ -41,6 +47,7 @@ $envVarEncoder = new class() {
     }
 };
 $twig->addFilter(new TwigFilter('env_var', [$envVarEncoder, 'encode'], ['is_safe' => ['all']]));
+$twig->addFilter(new TwigFilter('nginx_var', [$nginxVarEncoder, 'encode'], ['is_safe' => ['all']]));
 $twig->addFilter(new TwigFilter('normalize_endpoint', static function ($string) {
     return str_replace(['.', ':'], ['dot', '_'], $string);
 }, ['is_safe' => ['all']]));

--- a/generator/src/templates/nginx/http/glue.server.conf.twig
+++ b/generator/src/templates/nginx/http/glue.server.conf.twig
@@ -12,5 +12,5 @@
 
         fastcgi_param SPRYKER_API_HOST "{{ host }}";
         fastcgi_param SPRYKER_API_PORT "{{ externalPort }}";
-        fastcgi_param SPRYKER_GLUE_APPLICATION_CORS_ALLOW_ORIGIN "*";
+        fastcgi_param SPRYKER_GLUE_APPLICATION_CORS_ALLOW_ORIGIN "{{ endpointData['cors-allow-origin'] | default('') | nginx_var }}";
 {% endblock location %}


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-4807

#### Change log

### Bugfixes

- Added possibility to set `CORS allow origin` value via deploy.yml. Glue endpoints can be enhanced with `cors-allow-origin` property in order to propagate `SPRYKER_GLUE_APPLICATION_CORS_ALLOW_ORIGIN` environment variable.
- Changed default value of `SPRYKER_GLUE_APPLICATION_CORS_ALLOW_ORIGIN` from "*" to "" in the sake of security.

##### Backward compatibility
- Possible BC breaks for projects that use Glue endpoints from a browser application. Can be fixed by adding the application URL in deploy.yml files.

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md