### PR TITLE
SC-4827: Fixed wrong prompt in CLI on debian-based image

### DIFF
--- a/bin/standalone/cli.sh
+++ b/bin/standalone/cli.sh
@@ -59,7 +59,7 @@ fi
 
 # --------------------------
 if [ -z "${COMMAND}" ]; then
-    bash
+    bash --norc
 else
-    bash -c "${COMMAND}"
+    bash --norc -c "${COMMAND}"
 fi


### PR DESCRIPTION
### Description

- https://spryker.atlassian.net/browse/SC-4827

#### Related resources

- https://stackoverflow.com/questions/55591009/bin-bash-i-overwrites-ps1

#### Change log

- Fixed wrong prompt in CLI on debian-based image

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
