### PR TITLE
SC-5142: Introduced `max-request-body-size` to be set per application

### DIFF
--- a/generator/index.php
+++ b/generator/index.php
@@ -1118,7 +1118,9 @@ function buildSecrets(string $deploymentDir): array
 function generateOpenSshKeys(string $deploymentDir): array
 {
     $sshDir = $deploymentDir . DS . 'context' . DS . 'ssh';
-    mkdir($sshDir);
+    if (!file_exists($sshDir)) {
+        mkdir($sshDir);
+    }
 
     $generatePrivateKeyCommandTemplate = 'openssl genrsa -out %s 2048 2>&1';
     $generatePublicKeyCommandTemplate = 'openssl rsa -in %s -pubout -out %s 2>&1';

--- a/generator/src/templates/nginx/conf.d/debug.default.conf.twig
+++ b/generator/src/templates/nginx/conf.d/debug.default.conf.twig
@@ -7,6 +7,7 @@
     portToListen: _endpointDebugMap[endpoint],
     endpoint: endpoint,
     endpointData: endpointData,
+    applicationData: applicationData,
     auth: endpointData['auth'] | default([]),
     storeServices: regions[groupData['region']]['stores'][endpointData['store']]['services'] | default([]),
     upstream: (applicationName | lower) ~ ":9001",

--- a/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
+++ b/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
@@ -22,6 +22,7 @@ server {
 {% include "nginx/http/#{applicationData['application']}.server.conf.twig" with {
     endpoint: endpoint,
     endpointData: endpointData,
+    applicationData: applicationData,
     auth: endpointData['auth'] | default([]),
     storeServices: regions[groupData['region']]['stores'][endpointData['store']]['services'] | default([]),
     upstream: "${SPRYKER_NGINX_CGI_" ~ (applicationName | upper) ~ "}",

--- a/generator/src/templates/nginx/conf.d/gateway.default.conf.twig
+++ b/generator/src/templates/nginx/conf.d/gateway.default.conf.twig
@@ -3,6 +3,7 @@
 # Important for proxy server. E.g. to pass gzip correctly.
 proxy_http_version 1.1;
 server_names_hash_bucket_size 128;
+client_max_body_size 0;
 
 map $http_upgrade $connection_upgrade {
     default upgrade;

--- a/generator/src/templates/nginx/http/gateway/server.conf.twig
+++ b/generator/src/templates/nginx/http/gateway/server.conf.twig
@@ -21,6 +21,7 @@ server {
 {% endblock locations %}
     error_page 497 {{ desiredProtocol }}://$host{{ isPortCustom ? ':' ~ port : '' }}$request_uri;
 
+    client_max_body_size 0;
 {% include "nginx/vhost.d/timeouts.conf.twig" with { timeout: '60m' } %}
 }
 

--- a/generator/src/templates/nginx/vhost.d/glue.default.conf.twig
+++ b/generator/src/templates/nginx/vhost.d/glue.default.conf.twig
@@ -1,2 +1,1 @@
-    client_max_body_size 2m;
-
+    client_max_body_size {{ applicationData['http']['max-request-body-size'] | default('2m') }};

--- a/generator/src/templates/nginx/vhost.d/yves.default.conf.twig
+++ b/generator/src/templates/nginx/vhost.d/yves.default.conf.twig
@@ -1,0 +1,1 @@
+    client_max_body_size {{ applicationData['http']['max-request-body-size'] | default('1m') }};

--- a/generator/src/templates/nginx/vhost.d/zed.default.conf.twig
+++ b/generator/src/templates/nginx/vhost.d/zed.default.conf.twig
@@ -1,1 +1,1 @@
-    client_max_body_size 10m;
+    client_max_body_size {{ applicationData['http']['max-request-body-size'] | default('10m') }};


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-5142
- RG: https://release.spryker.com/release-groups/view/3081

#### Change log

- Introduced `groups: applications: http: max-request-body-size:` to be set per an application and defines maximum allowed request body size for all requests to the application.

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
