### PR TITLE
Bugfix for Spryker secrets not appearing in generated env files.

### DIFF
--- a/generator/src/templates/env/application/glue.env.twig
+++ b/generator/src/templates/env/application/glue.env.twig
@@ -1,4 +1,4 @@
-{% include "env/common.env.twig" with project %}
+{% include "env/common.env.twig" %}
 
 {% include "env/key_value_store/#{project['services']['key_value_store']['engine']}.env.twig" with {
     serviceData: project['services']['key_value_store'],

--- a/generator/src/templates/env/application/yves.env.twig
+++ b/generator/src/templates/env/application/yves.env.twig
@@ -1,4 +1,4 @@
-{% include "env/common.env.twig" with project %}
+{% include "env/common.env.twig" %}
 
 {% include "env/key_value_store/#{project['services']['key_value_store']['engine']}.env.twig" with {
     serviceData: project['services']['key_value_store'],

--- a/generator/src/templates/env/application/zed.env.twig
+++ b/generator/src/templates/env/application/zed.env.twig
@@ -1,4 +1,4 @@
-{% include "env/common.env.twig" with project %}
+{% include "env/common.env.twig" %}
 
 {% include "env/key_value_store/#{project['services']['key_value_store']['engine']}.env.twig" with {
     serviceData: project['services']['key_value_store'],

--- a/generator/src/templates/env/common.env.twig
+++ b/generator/src/templates/env/common.env.twig
@@ -21,7 +21,7 @@ BLACKFIRE_AGENT_SOCKET=tcp://blackfire:8707
 TIDEWAYS_DAEMON_URI=tcp://tideways:9135
 {% endif %}
 
-{% if _isAutoloadCacheEnabled %}
+{% if project['_isAutoloadCacheEnabled'] %}
 COMPOSER_AUTOLOAD_CACHE_ENABLED=1
 COMPOSER_AUTOLOAD_CACHE_URL=http://host.docker.internal:8999/
 {% endif %}


### PR DESCRIPTION
### Description

This commit fixes a bug in the generator, which caused the generated env files to not contain the Spryker secrets,
e.g. SPRYKER_OAUTH_KEY_PRIVATE. The bug occured when the used deploy.yml file contained a top-level 'project:' yaml
node. In for example zed.env.twig generator template, the common.env.twig was being included with the `project`
variable being extracted, leading to all child-nodes of `project` then being top-level nodes inside of common.env.twig.
This `project` variable is the `$projectData` from generator/index.php, and hence contains a representation of the yaml
structure of the deploy file.

In other words: If we extract `project` when including the common.env.twig, then all top-level yaml nodes from the deploy
file will be standalone twig variables in the common.env.twig. This means, that if we have a 'project:' yaml node
in the deploy file, then this yaml node will override the original `project` variable itself. This should not be
expected behaviour, and the author of this PR could not find any valid reason why this should be done.

So this commit removes the extraction of the `project` variable and fixes the only one (1) occurence in the common.env.twig
file where an extracted variable actually was being used. This variable is now being directly addressed as `project['variable']`.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
