### PR TITLE
Stick NPM to 6 version for BC

### DIFF
--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -32,7 +32,7 @@ RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
      ; fi'
 # Debian contains outdated NPM package
 RUN --mount=type=cache,id=npm,sharing=locked,target=/root/.npm \
-  bash -c 'if [ ! -z "$(which apt)" ]; then npm install npm@latest -g; fi'
+  bash -c 'if [ ! -z "$(which apt)" ]; then npm install npm@^6.0.0 -g; fi'
 
 RUN --mount=type=cache,id=apk,sharing=locked,target=/var/cache/apk mkdir -p /etc/apk && ln -vsf /var/cache/apk /etc/apk/cache && \
   bash -c 'if [ ! -z "$(which apk)" ]; then apk update && apk add \


### PR DESCRIPTION
### Description

- Ticket/Issue: <!-- Please, point to specific issue or Jira ticket -->

#### Change log

- Sets NPM version to 6 for BC reason for Debian OS.

