### PR TITLE
SC-6114: Fixed Xdebug v3 debugging mode.

### DIFF
--- a/context/php/debug/etc/php/debug.conf.d/69-xdebug.ini
+++ b/context/php/debug/etc/php/debug.conf.d/69-xdebug.ini
@@ -1,4 +1,9 @@
 zend_extension=xdebug.so
+
+# This is needed to prevent max recursion exception when Twig templates are very complicated
+xdebug.max_nesting_level=1000
+
+# XDebug v2
 xdebug.profiler_enable=0
 xdebug.trace_enable_trigger=1
 xdebug.profiler_enable_trigger=1
@@ -8,5 +13,10 @@ xdebug.remote_host=${SPRYKER_XDEBUG_HOST_IP}
 xdebug.remote_port=9000
 xdebug.profiler_output_dir=/tmp/xdebug/profiler
 xdebug.trace_output_dir=/tmp/xdebug/trace
-# This is needed to prevent max recursion exception when Twig templates are very complicated
-xdebug.max_nesting_level=1000
+
+# XDebug v3
+xdebug.mode=debug
+xdebug.start_with_request=yes
+xdebug.client_host=${SPRYKER_XDEBUG_HOST_IP}
+xdebug.client_port=9003
+xdebug.output_dir=/tmp/xdebug

--- a/docs/02-development/05-configuring-debugging.md
+++ b/docs/02-development/05-configuring-debugging.md
@@ -25,7 +25,7 @@ To configure Xdebug in PhpStorm:
 
 2. In the *Xdebug* section:
 
-      1. Depending on your requirements, enter a **Debug port**.
+      1. Depending on your requirements, enter a **Debug ports**. As an example: `9000,9003`, to support Xdebug v2 and v3.
       2. Select the **Can accept external connections** checkbox.
       3. Clear the **Force break at first line when no path mapping specified** and **Force break at first line when a script is outside the project** checkboxes.
 


### PR DESCRIPTION
### Description

- Ticket: https://spryker.atlassian.net/browse/SC-6114

PHP started to install XDebug version 3 by default. `docker/sdk` did not have a proper configuration for this specific version.

#### Related resources

- https://xdebug.org/docs/upgrade_guide

#### Change log

- Adjusted XDebug configuration to work with XDebug v3.

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
