### PR TITLE
Replace /dev/stderr with &2

### DIFF
--- a/bin/command/build/baked/build.sh
+++ b/bin/command/build/baked/build.sh
@@ -27,7 +27,7 @@ function Command::build() {
             Images::buildFrontend --force
             ;;
         *)
-            Console::error "Unknown build target '${subCommand}' is occurred. No action." > /dev/stderr
+            Console::error "Unknown build target '${subCommand}' is occurred. No action." >&2
             exit 1
             ;;
     esac

--- a/bin/command/build/baked/export.sh
+++ b/bin/command/build/baked/export.sh
@@ -66,7 +66,7 @@ function Command::export() {
             Images::printAll "${tag}"
             ;;
         *)
-            Console::error "Unknown export '${subCommand}' is occurred. No action. Usage: ${HELP_SCR}${SELF_SCRIPT} export images [-t <tag>]" > /dev/stderr
+            Console::error "Unknown export '${subCommand}' is occurred. No action. Usage: ${HELP_SCR}${SELF_SCRIPT} export images [-t <tag>]" >&2
             exit 1
             ;;
     esac

--- a/bin/command/build/mount/build.sh
+++ b/bin/command/build/mount/build.sh
@@ -30,7 +30,7 @@ function Command::build() {
             Images::buildFrontend --force
             ;;
         *)
-            Console::error "Unknown build target '${subCommand}' is occurred. No action." > /dev/stderr
+            Console::error "Unknown build target '${subCommand}' is occurred. No action." >&2
             exit 1
             ;;
     esac

--- a/bin/command/install/bootstrap.sh
+++ b/bin/command/install/bootstrap.sh
@@ -49,8 +49,8 @@ function Command::bootstrap() {
     if [ -n "${SKIP_BOOTSTRAP_IF_DONE}" ] && [ -f "${DESTINATION_DIR}/project.yml" ]; then
         if cmp -s "${DESTINATION_DIR}/project.yml" "${projectYaml}"; then
             if [ "$(cat "${DESTINATION_DIR}/_git" 2>/dev/null || true)" == "${gitHash}" ]; then
-                Console::log "${CYAN}Bootstrap is skipped as the branch is still the same.${NC}" >/dev/stderr
-                Console::log "${DGRAY}Do not use ${LGRAY}-s${DGRAY} option to bootstrap anyway.${NC}" >/dev/stderr
+                Console::log "${CYAN}Bootstrap is skipped as the branch is still the same.${NC}" >&2
+                Console::log "${DGRAY}Do not use ${LGRAY}-s${DGRAY} option to bootstrap anyway.${NC}" >&2
                 exit 0
             fi
         fi

--- a/bin/command/install/install.sh
+++ b/bin/command/install/install.sh
@@ -16,8 +16,8 @@ function Command::install() {
         return "${TRUE}"
     fi
 
-    Console::info "${INFO}Please, run the following commands in order to prepare the environment:" >/dev/stderr
-    Console::log "${BLOCKDARK}${output}\n${NC}\n\n" >/dev/stderr
+    Console::info "${INFO}Please, run the following commands in order to prepare the environment:" >&2
+    Console::log "${BLOCKDARK}${output}\n${NC}\n\n" >&2
 
     return "${TRUE}"
 }

--- a/sdk
+++ b/sdk
@@ -57,11 +57,11 @@ shift || true
 
 case "${command}" in
     boot | bootstrap)
-        bash "${FRAMEWORK_CWD}/standalone/logo/spryker-sdk.sh" > /dev/stderr
+        bash "${FRAMEWORK_CWD}/standalone/logo/spryker-sdk.sh" >&2
         Command::bootstrap "${@}"
         ;;
     help | '')
-        bash "${FRAMEWORK_CWD}/standalone/logo/spryker-sdk.sh" > /dev/stderr
+        bash "${FRAMEWORK_CWD}/standalone/logo/spryker-sdk.sh" >&2
         Registry::printHelp
         [ -f "${DEPLOY_SCRIPT}" ] && ${DEPLOY_SCRIPT} help "${@}"
         ;;


### PR DESCRIPTION
### Description

- Ticket/Issue: #181 

All occurrences of `/de/stderr` replaced with `>&2`. The `/dev/stderr` doesn't always exist.

#### Related resources

More details:
https://www.sichong.site/2020/01/09/dev-stdout-vs-2-a-dive-into-linux-stdio/

#### Change log

Replaced `>/dev/stderr` with `>&2`

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
