### PR TITLE
Enable coverage xdebug.mode

### DIFF
--- a/context/php/debug/etc/php/debug.conf.d/69-xdebug.ini
+++ b/context/php/debug/etc/php/debug.conf.d/69-xdebug.ini
@@ -15,7 +15,7 @@ xdebug.profiler_output_dir=/tmp/xdebug/profiler
 xdebug.trace_output_dir=/tmp/xdebug/trace
 
 # XDebug v3
-xdebug.mode=debug
+xdebug.mode=debug,coverage
 xdebug.start_with_request=yes
 xdebug.client_host=${SPRYKER_XDEBUG_HOST_IP}
 xdebug.client_port=9003


### PR DESCRIPTION
### Description

- Ticket/Issue: #184

The `coverage` mode is needed in order to run the test coverage analysis

#### Related resources

<https://xdebug.org/docs/all_settings#mode>

#### Change log

Enabled `coverage` xdebug mode

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
