### PR TITLE
Fix Version::parse interpreting number as octagonal

### DIFF
--- a/bin/lib/version.sh
+++ b/bin/lib/version.sh
@@ -6,5 +6,5 @@ import lib/string.sh
 
 function Version::parse {
     local version="$(String::trimWhitespaces "$@" | awk -F. '{ printf("%d%03d%03d%03d", $1,$2,$3,$4); }')"
-    echo $((version + 0))
+    echo $((10#$version + 0))
 }


### PR DESCRIPTION
### Description

Currently fails with input like "11.8.0" (running bash5 on MacOS Catalina) with a "value too great for base" error as the leading zeros make bash interpret the number as octagonal.

- Ticket: 

#### Change log

- Forced Version::parse to interpret given version as a decimal

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
