### PR TITLE
SC-6985: Impossible to override php.ini for debugging via deployment file

### DIFF
--- a/generator/index.php
+++ b/generator/index.php
@@ -448,6 +448,11 @@ file_put_contents(
     $twig->render('php/conf.d/99-from-deploy-yaml-php.ini.twig', $projectData)
 );
 
+file_put_contents(
+    $deploymentDir . DS . 'context' . DS . 'php' . DS . 'debug' . DS . 'etc' . DS . 'php' . DS . 'debug.conf.d' . DS . '99-from-deploy-yaml-php.ini',
+    $twig->render('php/conf.d/99-from-deploy-yaml-php.ini.twig', $projectData)
+);    
+
 $envVarEncoder->setIsActive(true);
 file_put_contents(
     $deploymentDir . DS . 'terraform/environment.tf',


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-6985

<!-- Please, write background  -->


#### Change log

- Fixed the possibility to override debug configuration via deployment file using of php.ini section.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
