### PR TITLE
[SC-7521] Extend Backoffice with MerchantPortal host and port

### DIFF
--- a/generator/src/templates/nginx/http/backoffice.server.conf.twig
+++ b/generator/src/templates/nginx/http/backoffice.server.conf.twig
@@ -39,4 +39,9 @@
         fastcgi_param SPRYKER_API_HOST "{{ project['_endpointMap'][endpointData['store']]['glue'] }}";
         fastcgi_param SPRYKER_API_PORT "{{ (project['_endpointMap'][endpointData['store']]['glue'] | split(':'))[1] | default(project['_defaultPort']) }}";
 {% endif %}
+
+{% if project['_endpointMap'][endpointData['store']]['merchant-portal'] is not empty %}
+        fastcgi_param SPRYKER_MP_HOST "{{ project['_endpointMap'][endpointData['store']]['merchant-portal'] }}";
+        fastcgi_param SPRYKER_MP_PORT "{{ (project['_endpointMap'][endpointData['store']]['merchant-portal'] | split(':'))[1] | default(project['_defaultPort']) }}";
+{% endif %}
 {% endblock location %}


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-7521

<!-- Please, write background  -->

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- Extended `backoffice` Nginx configuration with `merchant-portal` fastcgi params: `SPRYKER_MP_HOST`  and `SPRYKER_MP_PORT` if `merchant-portal` application is defined.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
