### PR TITLE
Fix CLI RPC status code and output

### DIFF
--- a/bin/standalone/cli-rpc.js
+++ b/bin/standalone/cli-rpc.js
@@ -26,29 +26,32 @@ class Dispatcher {
         response.setHeader('Content-Type', 'text/plain');
 
         let child;
+        let responseBuffer = '';
+
         try {
             child = spawn('bash', ['-c', requestBody]);
         } catch (error) {
             console.error(error);
-            response.write(error.message);
             response.statusCode = 400;
+            response.write(error.message);
             response.end();
             return;
         }
 
         console.info(requestBody);
         child.stdout.on('data', (chunk) => {
-            response.write(chunk.toString());
+            responseBuffer += chunk.toString();
         });
         child.on('close', (code) => {
             response.statusCode = code === 0 ? 200 : 400;
+            response.write(responseBuffer);
             response.end();
         });
 
         child.on('error', (error) => {
             console.error(error);
-            response.write(error.message);
             response.statusCode = 400;
+            response.write(error.message);
             response.end();
         });
     }
@@ -71,8 +74,8 @@ class Dispatcher {
 
             if (error) {
                 response.setHeader('Content-Type', 'text/plain');
-                response.write(error.toString());
                 response.statusCode = 500;
+                response.write(error.toString());
                 response.end();
                 return;
             }
@@ -82,8 +85,8 @@ class Dispatcher {
             }
 
             response.setHeader('Content-Type', 'text/yaml');
-            response.write(schemaContent);
             response.statusCode = 200;
+            response.write(schemaContent);
             response.end();
         });
     }

--- a/bin/standalone/cli-rpc.js
+++ b/bin/standalone/cli-rpc.js
@@ -42,6 +42,9 @@ class Dispatcher {
         child.stdout.on('data', (chunk) => {
             responseBuffer += chunk.toString();
         });
+        child.stderr.on('data', (chunk) => {
+            responseBuffer += chunk.toString();
+        });
         child.on('close', (code) => {
             response.statusCode = code === 0 ? 200 : 400;
             response.write(responseBuffer);


### PR DESCRIPTION
### Description

This PR fixes wrong build status and missing task output in Jenkins jobs.

#### Change log

1. Fixed response code in cli-rpc.js (cli-rpc responded with 200 instead of 400, because response.statusCode must be set before any response.write).
2. Transfer STDERR output with cli-rpc.js (missing output in jenkins)

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
