### PR TITLE
SC-6350: docker-sdk clean does not remove all images

### DIFF
--- a/bin/sdk/images/common.sh
+++ b/bin/sdk/images/common.sh
@@ -12,6 +12,8 @@ function Images::destroy() {
     # ${XARGS_NO_RUN_IF_EMPTY} must be without quotes
     # shellcheck disable=SC2086
     docker images --filter "reference=${SPRYKER_DOCKER_PREFIX}_*:${SPRYKER_DOCKER_TAG}" --format "{{.ID}}" | xargs ${XARGS_NO_RUN_IF_EMPTY} docker rmi -f
+    docker images --filter "reference=${SPRYKER_DOCKER_PREFIX}_builder_assets*" --format "{{.ID}}" | xargs ${XARGS_NO_RUN_IF_EMPTY} docker rmi -f
+    docker images --filter "reference=spryker_docker_sdk*" --format "{{.ID}}" | xargs ${XARGS_NO_RUN_IF_EMPTY} docker rmi -f
 
     docker rmi -f "${SPRYKER_DOCKER_PREFIX}_cli" || true
     docker rmi -f "${SPRYKER_DOCKER_PREFIX}_app" || true


### PR DESCRIPTION
### Description

- Ticket: https://spryker.atlassian.net/browse/SC-6350
- Issue: https://github.com/spryker/docker-sdk/issues/188

#### Change log

- adjusted `clean` function for dropping all spryker images

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
