### PR TITLE
SC-5760: Cloud: Fatal errors caused by --no-dev mode in suite-nonsplit.

### DIFF
--- a/generator/src/templates/deploy.bash.twig
+++ b/generator/src/templates/deploy.bash.twig
@@ -115,6 +115,7 @@ readonly SPRYKER_DOCKER_PREFIX=${COMPOSE_PROJECT_NAME}
 readonly SPRYKER_DOCKER_TAG="{{ tag | default('1.0') }}"
 readonly SPRYKER_FRONTEND_IMAGE="{{ assets['image'] | default('nginx:alpine') }}"
 readonly SPRYKER_COMPOSER_MODE="{{ composer.mode | default('') }}"
+readonly SPRYKER_COMPOSER_DEV_MODE_ENABLED="{{ '--no-dev' in composer.mode ? 0 : 1 }}"
 readonly SPRYKER_COMPOSER_AUTOLOAD="{{ composer.autoload | default('') }}"
 readonly SPRYKER_LOG_DIRECTORY="{{ docker['logs']['path'] | default('/var/log/spryker') }}"
 readonly SPRYKER_ASSETS_MODE="{{ assets['mode'] | default('development') }}"


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-5760

#### Related resources

- Suite-nonsplit PR: https://github.com/spryker/suite-nonsplit/pull/5889

#### Change log

- added new env variable `SPRYKER_COMPOSER_DEV_MODE_ENABLED` based on substring `composer.mode` from deploy  yml

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
