### PR TITLE
Add possibility to inject DNS resolver values

### DIFF
--- a/bin/sdk/images/common.sh
+++ b/bin/sdk/images/common.sh
@@ -149,6 +149,8 @@ function Images::_buildFrontend() {
         --build-arg "SPRYKER_FRONTEND_IMAGE=${SPRYKER_FRONTEND_IMAGE}" \
         --build-arg "SPRYKER_BUILD_HASH=${SPRYKER_BUILD_HASH:-"current"}" \
         --build-arg "SPRYKER_BUILD_STAMP=${SPRYKER_BUILD_STAMP:-""}" \
+        --build-arg "SPRYKER_DNS_RESOLVER_FLAGS=${SPRYKER_DNS_RESOLVER_FLAGS:-"valid=10s ipv6=off"}" \
+        --build-arg "SPRYKER_DNS_RESOLVER_IP=${SPRYKER_DNS_RESOLVER_IP:-"127.0.0.11"}" \
         "${DEPLOYMENT_PATH}/context" 1>&2
 
     docker build \

--- a/images/common/frontend/Dockerfile
+++ b/images/common/frontend/Dockerfile
@@ -12,8 +12,10 @@ COPY --chown=root:root nginx/auth /etc/nginx/auth
 COPY --chown=root:root nginx/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
-ENV SPRYKER_DNS_RESOLVER_FLAGS="valid=10s ipv6=off"
-ENV SPRYKER_DNS_RESOLVER_IP="127.0.0.11"
+ARG SPRYKER_DNS_RESOLVER_FLAGS="valid=10s ipv6=off"
+ENV SPRYKER_DNS_RESOLVER_FLAGS=${SPRYKER_DNS_RESOLVER_FLAGS}
+ARG SPRYKER_DNS_RESOLVER_IP='127.0.0.11'
+ENV SPRYKER_DNS_RESOLVER_IP=${SPRYKER_DNS_RESOLVER_IP}
 
 # Build info
 ARG SPRYKER_BUILD_HASH='current'


### PR DESCRIPTION
### Description

Regarding to https://github.com/spryker/docker-sdk/commit/ba3e895ebc6a43199f96f1f90be83a1a6186aa92 

The new `global` hard coded DNS resolver IP 127.0.0.11 in `images/common/frontend/Dockerfile` is a problem in the context of kubernetes. Kubernetes has its own DNS. So we (as a customer) need the possibility to override the env var `SPRYKER_DNS_RESOLVER_IP`

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
