### PR TITLE
To avoid sync issue on MAC OS - delete mutagen sessions with obsolete docker id

### DIFF
--- a/bin/sdk/mount/mutagen.sh
+++ b/bin/sdk/mount/mutagen.sh
@@ -25,6 +25,8 @@ function Mount::Mutagen::beforeUp() {
     # The volume will not be deleted if any app container is running.
     docker volume rm "${SPRYKER_SYNC_VOLUME}" >/dev/null 2>&1 || true
 
+    deleteMutagenSessionsWithObsoleteDockerId
+
     # Clean content of the sync volume if the sync session is terminated or halted.
     sessionStatus=$(mutagen sync list "${SPRYKER_SYNC_SESSION_NAME}" 2>/dev/null | grep 'Status:' | awk '{print $2}' || echo '')
     if [ -z "${sessionStatus}" ] || [ "${sessionStatus}" == 'Halted' ]; then
@@ -33,6 +35,38 @@ function Mount::Mutagen::beforeUp() {
         docker run -i --rm -v "${SPRYKER_SYNC_VOLUME}:/data" busybox find /data/ ! -path /data/ -delete >/dev/null 2>&1 || true
         Console::end "[OK]"
     fi
+}
+
+function deleteMutagenSessionsWithObsoleteDockerId() {
+    dockerId=$(docker info --format '{{.ID}}' 2>/dev/null | awk '{ gsub(":","_",$1); print $1 }' || echo '')
+
+    if [ -z "$dockerId" ]; then
+        Console::warn "Docker ID is empty, mutagen session check does not work, please repair the script."
+        return
+    fi
+
+    Console::log "Checking mutagen sessions for docker ID: ${dockerId}"
+
+    sessionIds=$(mutagen sync list "${SPRYKER_SYNC_SESSION_NAME}" 2>/dev/null | grep 'Identifier:' | awk '{print $2}' || echo '')
+
+    for sessionId in ${sessionIds}; do
+        if [ -z "$dockerId" ]; then
+            Console::warn "Session ID is empty, session check skipped, please repair the script."
+            continue
+        fi
+
+        sessionDockerId=$(mutagen sync list "${sessionId}" 2>/dev/null | grep 'io.mutagen.compose.daemon.identifier:' | awk '{print $2}' || echo '')
+
+        if [ -z "$sessionDockerId" ]; then
+            Console::warn "Docker ID for session with ID ${sessionId} is empty, session check skipped, please repair the script."
+            continue
+        fi
+
+        if [ "$sessionDockerId" != "$dockerId" ]; then
+            mutagen sync terminate "${sessionId}"
+            Console::log "${INFO}Mutagen session with ID ${sessionId} is obsolete and deleted."
+        fi
+    done
 }
 
 # This is necessary due to https://github.com/mutagen-io/mutagen/issues/224

--- a/bin/sdk/mount/mutagen.sh
+++ b/bin/sdk/mount/mutagen.sh
@@ -41,7 +41,7 @@ function terminateMutagenSessionsWithObsoleteDockerId() {
     dockerId=$(docker info --format '{{.ID}}' 2>/dev/null | awk '{ gsub(":","_",$1); print $1 }' || echo '')
 
     if [ -z "$dockerId" ]; then
-        Console::warn "Docker ID is empty, mutagen session check does not work, please repair the script."
+        Console::error "${WARN}Docker ID is empty, please check the script and try again."
         return
     fi
 
@@ -51,20 +51,20 @@ function terminateMutagenSessionsWithObsoleteDockerId() {
 
     for sessionId in ${sessionIds}; do
         if [ -z "$dockerId" ]; then
-            Console::warn "Session ID is empty, session check skipped, please repair the script."
+            Console::warn "Session ID is empty, please check the script and try again."
             continue
         fi
 
         sessionDockerId=$(mutagen sync list "${sessionId}" 2>/dev/null | grep 'io.mutagen.compose.daemon.identifier:' | awk '{print $2}' || echo '')
 
         if [ -z "$sessionDockerId" ]; then
-            Console::warn "Docker ID for session with ID ${sessionId} is empty, session check skipped, please repair the script."
+           Console::warn "Docker ID for session ${sessionId} is empty, please check the script and try again."
             continue
         fi
 
         if [ "$sessionDockerId" != "$dockerId" ]; then
             mutagen sync terminate "${sessionId}"
-            Console::log "${INFO}Mutagen session with ID ${sessionId} is obsolete and deleted."
+            Console::log "Mutagen session ${sessionId} has been terminated."
         fi
     done
 }

--- a/bin/sdk/mount/mutagen.sh
+++ b/bin/sdk/mount/mutagen.sh
@@ -50,7 +50,7 @@ function terminateMutagenSessionsWithObsoleteDockerId() {
     sessionIds=$(mutagen sync list "${SPRYKER_SYNC_SESSION_NAME}" 2>/dev/null | grep 'Identifier:' | awk '{print $2}' || echo '')
 
     for sessionId in ${sessionIds}; do
-        if [ -z "$dockerId" ]; then
+        if [ -z "$sessionId" ]; then
             Console::warn "Session ID is empty, please check the script and try again."
             continue
         fi

--- a/bin/sdk/mount/mutagen.sh
+++ b/bin/sdk/mount/mutagen.sh
@@ -25,7 +25,7 @@ function Mount::Mutagen::beforeUp() {
     # The volume will not be deleted if any app container is running.
     docker volume rm "${SPRYKER_SYNC_VOLUME}" >/dev/null 2>&1 || true
 
-    deleteMutagenSessionsWithObsoleteDockerId
+    terminateMutagenSessionsWithObsoleteDockerId
 
     # Clean content of the sync volume if the sync session is terminated or halted.
     sessionStatus=$(mutagen sync list "${SPRYKER_SYNC_SESSION_NAME}" 2>/dev/null | grep 'Status:' | awk '{print $2}' || echo '')
@@ -37,7 +37,7 @@ function Mount::Mutagen::beforeUp() {
     fi
 }
 
-function deleteMutagenSessionsWithObsoleteDockerId() {
+function terminateMutagenSessionsWithObsoleteDockerId() {
     dockerId=$(docker info --format '{{.ID}}' 2>/dev/null | awk '{ gsub(":","_",$1); print $1 }' || echo '')
 
     if [ -z "$dockerId" ]; then


### PR DESCRIPTION
### Description

On MAC OS sometimes there is a syncronisation issue after restart of the Docker-Desktop due to an obsolete mutagen session(s). 
Usually this problem arises after restart of the MAC OS, because it restarts the Docker-Desktop.
This mutagen problem under MAC OS is known and described: https://github.com/mutagen-io/mutagen/issues/243
The only suggestion in the issue is to delete the mutagen sessions automatically in a startup script: https://github.com/mutagen-io/mutagen/issues/243#issuecomment-868470834.
In such a case Spryker officially suggests to delete the Mutagen sessions manually: https://documentation.spryker.com/docs/mutagen-synchronization-issue
That suggestion from Spryker takes time of every Spryker developer under MAC OS, who restarts the OS.
The PR provides automatical deletion of the obsolete mutagen sessions to save time of developers after restarting the MAC OS.

**How to reproduce the Problem in a working environment:**

1. Check the current Mutagen session(s):
```
mutagen sync list
```
2. Stop the Docker-Application:
```
docker/sdk stop
```
3. Restart the Docker-Desktop via a user interface or:
```
osascript -e 'quit app "Docker"' && open -a Docker
```
4. Run the Docker-Application:
```
docker/sdk up
```
5. Check the current Mutagen session(s), that all of them from 1. are present and a new one is created:
```
mutagen sync list
```

**How to check the solution in a working environment:**

0. Update the file `deployment/default/bin/sdk/mount/mutagen.sh`:
```
docker/sdk bootstrap
```
or simply
```
cp bin/sdk/mount/mutagen.sh deployment/default/bin/sdk/mount/mutagen.sh
```
1.-4. The same.

5. Check the current Mutagen session(s), that all of them from 1. are deleted and a new one is created:
```
mutagen sync list
```

#### Related resources

This mutagen problem under MAC OS is known and described: https://github.com/mutagen-io/mutagen/issues/243
The only suggestion in the issue is to delete the mutagen sessions automatically in a startup script: https://github.com/mutagen-io/mutagen/issues/243#issuecomment-868470834.
Spryker officially suggests to delete the mutagen sessions manually: https://documentation.spryker.com/docs/mutagen-synchronization-issue 

#### Change log

To avoid mutagen sync issue on MAC OS - added deletion of mutagen sessions with obsolete docker id.

### Checklist
- [ X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
