### PR TITLE
Fix typo in debug.default.conf.twig

### DIFF
--- a/generator/src/templates/nginx/conf.d/debug.default.conf.twig
+++ b/generator/src/templates/nginx/conf.d/debug.default.conf.twig
@@ -12,7 +12,7 @@
     auth: endpointData['auth'] | default([]),
     storeServices: regions[groupData['region']]['stores'][endpointData['store']]['services'] | default([]),
     upstream: (applicationName | lower) ~ ":9001",
-    zedHost: (zedHost | split(':') | first) ~ ':' ~ (_endpointDebugMap[zedEndpoint]),
+    zedHost: (zedHost | split(':') | first) ~ ':' ~ (_endpointDebugMap[zedHost]),
     timeout: '60m',
     project: _context
 } %}


### PR DESCRIPTION
Fix typo in `debug.default.conf.twig`: Variable zedEndpoint is not existing, probably a typo and `zedHost` was meant, which at least leads to passing the correct port to the `$application.server.conf.twig` template (normally port 1001).

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md

### Fixes
- Fixed incorrect host in the debug configuration.
