### PR TITLE
Fix docker-compose version check bug.

### DIFF
--- a/bin/environment/docker-compose.sh
+++ b/bin/environment/docker-compose.sh
@@ -11,7 +11,7 @@ function Environment::checkDockerComposeVersion() {
     local requiredMinimalVersion=${1:-'1.22.0'}
     local installedVersion=$(
         command -v docker-compose >/dev/null
-        test $? -eq 0 && docker-compose version --short || echo 0
+        test $? -eq 0 && docker-compose version --short | tr -d 'v' || echo 0
     )
 
     if [ "${installedVersion}" == 0 ]; then


### PR DESCRIPTION
With newer Version docker the "docker-compose version --short" command gives out a version number string with "v" at the beginning, so the later comparison failed with this misleading error message:  
`Docker Compose version v2.1.1 is not supported. Please update Docker Compose to at least 1.22.0. `
With the help of "tr" to remove the leading "v" will fix this problem.

### Description

- Ticket/Issue: <!-- Please, point to specific issue or Jira ticket -->

<!-- Please, write background  -->

#### Related resources

<!-- Reference all related PRs or other resources -->

- <!-- URL_HERE -->

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- <!-- Please, add all changes one by one. E.g "Adjusted something", "Removed something"... -->

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
