### PR TITLE
SC-8485: Assets are not available during production deployment

### DIFF
--- a/generator/src/templates/nginx/entrypoint.sh.twig
+++ b/generator/src/templates/nginx/entrypoint.sh.twig
@@ -1,5 +1,5 @@
 #!/bin/sh
-{% set envVariables = ["\$ALLOWED_IP"] %}
+{% set envVariables = ["\$ALLOWED_IP", "\$SPRYKER_BUILD_HASH"] %}
 {% for groupData in groups %}
 {% for applicationName, applicationData in groupData['applications'] %}
 {% if applicationData['application'] != 'static' %}

--- a/generator/src/templates/nginx/http/static.conf.twig
+++ b/generator/src/templates/nginx/http/static.conf.twig
@@ -4,7 +4,22 @@
         add_header  Pragma public;
         add_header  Cache-Control "public, must-revalidate, proxy-revalidate";
         etag on;
-        try_files   $uri =404;
+        try_files   $uri @assets;
+    }
+
+    location @assets {
+        rewrite ^/assets/[^/]+/(.*)$ /__assets__fallback/${SPRYKER_BUILD_HASH}/$1 last;
+    }
+
+    location ~* /__assets__fallback/(.*) {
+        access_log        off;
+        add_header        Last-Modified 'Thu, 01 Jan 1970 00:00:00 GMT';
+        add_header        Cache-Control 'no-store, no-cache';
+        if_modified_since off;
+        expires           off;
+        etag              off;
+
+        try_files         /assets/$1 =404;
     }
 
     location / {


### PR DESCRIPTION
### Description

- Ticket/Issue:  https://spryker.atlassian.net/browse/SC-8485

#### Change log

- Fixed assets inaccessibility with assets fallback location for Nginx configuration based on the current value of the `SPRYKER_BUILD_HASH` environment variable.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
