### PR TITLE
SC-8503 Cloud on-boarding

### DIFF
--- a/bin/sdk/images/baked.sh
+++ b/bin/sdk/images/baked.sh
@@ -38,5 +38,6 @@ function Images::buildFrontend() {
 
     Images::_buildFrontend baked
     Images::_buildGateway
+    Images::_buildRedisReader
     Images::tagFrontend "${SPRYKER_DOCKER_TAG}"
 }

--- a/bin/sdk/images/common.sh
+++ b/bin/sdk/images/common.sh
@@ -182,6 +182,18 @@ function Images::_buildGateway() {
         "${DEPLOYMENT_PATH}/context" 1>&2
 }
 
+function Images::_buildRedisReader() {
+    local redisReaderImage="${SPRYKER_DOCKER_PREFIX}_redis_reader:${SPRYKER_DOCKER_TAG}"
+
+    Console::verbose "${INFO}Building redis-reader image${NC}"
+
+    docker build \
+        -t "${redisReaderImage}" \
+        -f "${DEPLOYMENT_PATH}/images/common/services/redis-reader/Dockerfile" \
+        --progress="${PROGRESS_TYPE}" \
+        "${DEPLOYMENT_PATH}/context" 1>&2
+}
+
 function Images::_tagByApp() {
     local applicationName=$1
     local imageName=$2

--- a/bin/sdk/images/mount.sh
+++ b/bin/sdk/images/mount.sh
@@ -38,5 +38,6 @@ function Images::buildFrontend() {
 
     Images::_buildFrontend mount
     Images::_buildGateway
+    Images::_buildRedisReader
     Images::tagFrontend "${SPRYKER_DOCKER_TAG}"
 }

--- a/generator/src/templates/service/elastic/7.8/elastic.yml.twig
+++ b/generator/src/templates/service/elastic/7.8/elastic.yml.twig
@@ -1,0 +1,22 @@
+  {{ serviceName }}:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
+    networks:
+        - private
+    labels:
+      'spryker.app.name': search
+      'spryker.app.type': services
+      'spryker.project': ${SPRYKER_DOCKER_PREFIX}:${SPRYKER_DOCKER_TAG}
+    healthcheck:
+        test: ["CMD", "curl", "-f", "localhost:9200/_cat/health"]
+        interval: 10s
+        timeout: 5s
+        retries: 5
+    ulimits:
+        memlock:
+            soft: -1
+            hard: -1
+    environment:
+        ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    volumes:
+        - {{ serviceName }}-{{ serviceData['engine'] }}-data:/usr/share/elasticsearch/data:rw
+        - ./${DEPLOYMENT_PATH}/context/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro

--- a/generator/src/templates/service/kibana/7.8/kibana.yml.twig
+++ b/generator/src/templates/service/kibana/7.8/kibana.yml.twig
@@ -1,0 +1,20 @@
+  {{ serviceName }}:
+    image: docker.elastic.co/kibana/kibana:7.8.0
+    networks:
+        - private
+    labels:
+      'spryker.app.name': kibana
+      'spryker.app.type': services
+      'spryker.project': ${SPRYKER_DOCKER_PREFIX}:${SPRYKER_DOCKER_TAG}
+    healthcheck:
+        test: curl --cacert /usr/share/elasticsearch/config/certs/ca/ca.crt -s https://localhost:5601 >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi
+        interval: 30s
+        timeout: 10s
+        retries: 5
+    environment:
+        - NODE_OPTIONS=--max-old-space-size=5000
+    depends_on:
+        - search
+    volumes:
+        - {{ serviceName }}-{{ serviceData['engine'] }}-data:/usr/share/kibana/data:rw
+        - ./${DEPLOYMENT_PATH}/context/kibana/7.6/kibana.yml:/usr/share/kibana/config/kibana.yml:ro

--- a/generator/src/templates/service/redis-reader/default/redis-reader.yml.twig
+++ b/generator/src/templates/service/redis-reader/default/redis-reader.yml.twig
@@ -1,0 +1,15 @@
+  {{ serviceName }}:
+    build:
+      context: ./${DEPLOYMENT_PATH}/images/common/services/redis-reader/
+      dockerfile: Dockerfile
+    networks:
+      - private
+    environment:
+        REDIS_HOST: "{{ serviceData['redis_host'] }}"
+        REDIS_PORT: "{{ serviceData['redis_port'] }}"
+        REDIS_DB: "{{ serviceData['redis_db'] }}"
+        PORT: "{{ serviceData['port'] }}"
+    labels:
+      'spryker.app.name': redis-reader
+      'spryker.app.type': agents
+      'spryker.project': ${SPRYKER_DOCKER_PREFIX}:${SPRYKER_DOCKER_TAG}

--- a/images/common/services/redis-reader/Dockerfile
+++ b/images/common/services/redis-reader/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:alpine3.15 AS redis-reader-daemon
+
+ENV PORT=3000
+ENV REDIS_HOST='127.0.0.1'
+ENV REDIS_PORT=6379
+ENV REDIS_DB=0
+
+RUN git clone https://github.com/zyuzka/redis-reader.git /redis-reader-daemon
+
+WORKDIR /redis-reader-daemon
+
+RUN npm install
+
+ENTRYPOINT ["node", "app.js"]


### PR DESCRIPTION
- add new versions `7.8` for `elastic` and `kibana` services
- add new service `redis-reader` for checking redis status

### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-8503

#### Change log

- add new versions `7.8` for `elastic` and `kibana` services
- add new service `redis-reader` for checking key-value storage status

#### Related PRs
- https://github.com/spryker/suite-nonsplit/pull/6338

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
