### PR TITLE
Increase the default number of Redis databases from 64 to 1024

### DIFF
--- a/context/redis/redis.conf
+++ b/context/redis/redis.conf
@@ -1,4 +1,4 @@
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where
 # dbid is a number between 0 and 'databases'-1
-databases 64
+databases 1024


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/ALO-314

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- Increased the default number of Redis databases from 64 to 1024.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
