### PR TITLE
feat(): disable 'Installer::hosts' for all '*.localhost' TLDs, not only 'localhost'

### DIFF
--- a/generator/index.php
+++ b/generator/index.php
@@ -1080,10 +1080,23 @@ function buildComposerAutoloadConfig(array $projectData): string
     return trim($projectData['composer']['autoload'] ?? ($projectData['_fileMode'] === 'baked' ? '--classmap-authoritative' : ''));
 }
 
+function endsWith($haystack, $needle) {
+    return substr_compare($haystack, $needle, -strlen($needle)) === 0;
+}
+
 function buildDataForRequirementAnalyzer(array $projectData): array
 {
     $hosts = $projectData['_hosts'];
-    unset($hosts['localhost']);
+
+    // all domain names ending with TLD 'localhost' do not need to be listed in /etc/hosts 
+    // see https://www.ietf.org/rfc/rfc2606.txt
+    foreach ($hosts as $hostNameKey => $hostNameValue)
+     {
+         if (endsWith($hostNameKey, 'localhost')) 
+         {
+            unset($hosts[$hostNameKey]);
+         }
+     }
 
     return [
         'hosts' => implode(' ', $hosts),


### PR DESCRIPTION

### Description

SDK uses '*.local' as TLD, which needs customized host entries in '/etc/hosts'.
I  use '*.localhost' as local TLD for my Spryker Shop services, like 'yves.de.b2c.development.localhost'.

Then I do not need an installer instruction like 'Please add these host entires to /etc/hosts'.

So the requirement is:
When using '*.localhost' as tld domain name for a host the host name shall also (like 'localhost itself) not be included in the hosts-array created by the 'Installer::hosts' boot step.

Ref: ./docker/bin/installer/hosts.sh

<!-- Please, write background  -->

#### Rationale

At MMS we use '*.localhost' as local TLD for our services, like 'yves.de.b2c.env-1.localhost'.

We use multiple environments concurrently at one docker site (e.g. a WSL2) with multiple applications (b2c, b2b, suite, our own's...) and tear them up and down quickly and often. 

We do not want to mange '/etc/hosts' all the time and thus use '*.localhost' as TLD which automatically maps to 127.0.0.1 (see see https://www.ietf.org/rfc/rfc2606.txt)

#### Related resources

<!-- Reference all related PRs or other resources -->

- <!-- URL_HERE -->

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- <!-- Please, add all changes one by one. E.g "Adjusted something", "Removed something"... -->

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
