### PR TITLE
feat(): added 'adminer' service

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ For contribution guidelines, see [Code contribution guide](https://documentation
 |   |   | 7.6 |
 |   |   | 7.10 |
 | blackfire  | blackfire  | latest |
+| adminer  | adminer  | latest |

--- a/generator/src/templates/nginx/http/gateway/adminer.server.conf.twig
+++ b/generator/src/templates/nginx/http/gateway/adminer.server.conf.twig
@@ -1,0 +1,2 @@
+{% extends "nginx/http/gateway/server.conf.twig" %}
+{% block upstream %}{{ upstream }}:8080{% endblock upstream %}

--- a/generator/src/templates/service/adminer/default/adminer.yml.twig
+++ b/generator/src/templates/service/adminer/default/adminer.yml.twig
@@ -1,0 +1,1 @@
+{% include "service/#{engine}/latest/#{engine}.yml.twig" with _context only %}

--- a/generator/src/templates/service/adminer/latest/adminer.yml.twig
+++ b/generator/src/templates/service/adminer/latest/adminer.yml.twig
@@ -1,0 +1,8 @@
+  {{ serviceName }}:
+    image: adminer
+    networks:
+      - private
+    labels:
+      'spryker.app.name': adminer
+      'spryker.app.type': services
+      'spryker.project': ${SPRYKER_DOCKER_PREFIX}:${SPRYKER_DOCKER_TAG}


### PR DESCRIPTION
### Description

[Adminer](https://www.adminer.org) is a nice and simple database-WebGUI. 

Just add in your deploy-file sth. like

```yaml
  adminer:
        engine: adminer
        endpoints:
            db.b2c.dev-1.localhost:
```

and you'll have a further service available (like 'rediscommander').


### Checklist
- [ x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
