### PR TITLE
SC-8863: Endpoints with .localhost do not require update of /etc/hosts

### DIFF
--- a/docs/06-configuring-services.md
+++ b/docs/06-configuring-services.md
@@ -165,7 +165,7 @@ services:
         endpoints:
             {custom_endpoint}:
 ```
-2. Adjust host file:
+2. Adjust host file, if `{custom_endpoint}` aren't ending on `.localhost`:
 ```bash
 echo "127.0.0.1 {custom_endpoint}" | sudo tee -a /etc/hosts
 ```
@@ -211,7 +211,7 @@ services:
             {custom_endpoint}:
 ```
 
-2. Adjust the `host` file:
+2. Adjust the `host` file, if `{custom_endpoint}` aren't ending on `.localhost`:
 ```bash
 echo "127.0.0.1 {custom_endpoint}" | sudo tee -a /etc/hosts
 ```
@@ -252,7 +252,7 @@ services:
             {custom_endpoint}: //redis-commander.spryker.local:
 ```
 
-2. Adjust hosts file:
+2. Adjust hosts file, if `{custom_endpoint}` aren't ending on `.localhost`:
 ```bash
 echo "127.0.0.1 {custom_endpoint}" | sudo tee -a /etc/hosts
 ```

--- a/docs/06-installation/02-installation-guides/02-installing-in-development-mode-on-macos-and-linux.md
+++ b/docs/06-installation/02-installation-guides/02-installing-in-development-mode-on-macos-and-linux.md
@@ -74,7 +74,7 @@ Once you finish the setup, you don't need to run `bootstrap` to start the instan
 :::
 
 8. Update the `hosts` file:
-Follow the installation instructions in the white box from the `docker/sdk bootstrap` command execution results to prepare the environment.
+Follow the installation instructions in the white box from the `docker/sdk bootstrap` command execution results to prepare the environment. All endpoints ending on `*.localhost` are resolving automatically.
 
 :::(Info) ()
  You can run `docker/sdk install` after `bootstrap` to get the list of the instructions.

--- a/docs/06-installation/02-installation-guides/02-installing-in-development-mode-on-macos-and-linux.md
+++ b/docs/06-installation/02-installation-guides/02-installing-in-development-mode-on-macos-and-linux.md
@@ -73,14 +73,9 @@ docker/sdk bootstrap deploy.dev.yml
 Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after you update the Docker SDK or the deploy file.
 :::
 
-8. Update the `hosts` file:
-Follow the installation instructions in the white box from the `docker/sdk bootstrap` command execution results to prepare the environment. All endpoints ending on `*.localhost` are resolving automatically.
+8. If the `bootstrap` command returned instructions for preparing your environment, execute them.
 
-:::(Info) ()
- You can run `docker/sdk install` after `bootstrap` to get the list of the instructions.
-:::
-
-9. Once the job finishes, build and start the instance:
+9. Build and start the instance:
     
 ```bash
 docker/sdk up

--- a/docs/06-installation/02-installation-guides/02-installing-in-development-mode-on-macos-and-linux.md
+++ b/docs/06-installation/02-installation-guides/02-installing-in-development-mode-on-macos-and-linux.md
@@ -73,7 +73,11 @@ docker/sdk bootstrap deploy.dev.yml
 Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after you update the Docker SDK or the deploy file.
 :::
 
-8. If the `bootstrap` command returned instructions for preparing your environment, execute them.
+8. If the `bootstrap` command returned instructions for preparing your environment, follow them.
+
+:::(Info) ()
+To double-check if there are any instructions, run `docker/sdk install`.
+:::
 
 9. Build and start the instance:
     

--- a/generator/index.php
+++ b/generator/index.php
@@ -1080,20 +1080,30 @@ function buildComposerAutoloadConfig(array $projectData): string
     return trim($projectData['composer']['autoload'] ?? ($projectData['_fileMode'] === 'baked' ? '--classmap-authoritative' : ''));
 }
 
-function endsWith($haystack, $needle) {
-    return substr_compare($haystack, $needle, -strlen($needle)) === 0;
+function endsWith(string $haystack, string $needle): bool
+{
+    if (function_exists('str_ends_with')) {
+        return str_ends_with($haystack, $needle);
+    }
+
+    if ($needle === '') {
+        return true;
+    }
+
+    $needleLength = strlen($needle);
+
+    return substr($haystack, -$needleLength) === $needle;
 }
 
 function buildDataForRequirementAnalyzer(array $projectData): array
 {
     $hosts = $projectData['_hosts'];
 
-    // all domain names ending with TLD 'localhost' do not need to be listed in /etc/hosts 
+    // all domain names ending with TLD 'localhost' do not need to be listed in /etc/hosts
     // see https://www.ietf.org/rfc/rfc2606.txt
     foreach ($hosts as $hostNameKey => $hostNameValue)
      {
-         if (endsWith($hostNameKey, 'localhost')) 
-         {
+         if (endsWith($hostNameKey, 'localhost')) {
             unset($hosts[$hostNameKey]);
          }
      }


### PR DESCRIPTION
### Description

- Ticket/Issue:  https://spryker.atlassian.net/browse/SC-8863

#### Related resources

- Original PR: https://github.com/spryker/docker-sdk/pull/292

#### Change log

- Adjusted host-helper functionality for excluded *.localhost hosts from /etc/hosts update-message

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
