### PR TITLE
SC-7329: Provide environment variable with the list of active stores

### DIFF
--- a/generator/src/templates/env/common.env.twig
+++ b/generator/src/templates/env/common.env.twig
@@ -1,5 +1,6 @@
 APPLICATION_ENV={{ project['environment'] }}
 SPRYKER_REGION={{ regionName }}
+SPRYKER_ACTIVE_STORES={{ project['regions'][regionName]['stores'] | keys | join(',') }}
 
 SPRYKER_SMTP_HOST=mail_catcher
 SPRYKER_SMTP_PORT=1025

--- a/generator/src/templates/terraform/environment.common.tf.twig
+++ b/generator/src/templates/terraform/environment.common.tf.twig
@@ -1,4 +1,4 @@
       APPLICATION_ENV = {{ project['environment'] | tf_var }}
       SPRYKER_ZED_SSL_ENABLED = {{ ((project['docker']['ssl']['enabled'] | default(false)) ? 1 : 0) | tf_var }}
       SPRYKER_DEBUG_ENABLED = {{ (project['docker']['debug']['enabled'] ? 1 : 0) | tf_var }}
-      SPRYKER_ACTIVE_STORES = "{{ project['regions'][regionName]['stores'] | keys | join(',') }}"
+      SPRYKER_ACTIVE_STORES = "{{ project['regions'][regionName]['stores'] | keys | join(',') | tf_var }}"

--- a/generator/src/templates/terraform/environment.common.tf.twig
+++ b/generator/src/templates/terraform/environment.common.tf.twig
@@ -1,3 +1,4 @@
       APPLICATION_ENV = {{ project['environment'] | tf_var }}
       SPRYKER_ZED_SSL_ENABLED = {{ ((project['docker']['ssl']['enabled'] | default(false)) ? 1 : 0) | tf_var }}
       SPRYKER_DEBUG_ENABLED = {{ (project['docker']['debug']['enabled'] ? 1 : 0) | tf_var }}
+      SPRYKER_ACTIVE_STORES = "{{ project['regions'][regionName]['stores'] | keys | join(',') }}"

--- a/generator/src/templates/terraform/store.env.twig
+++ b/generator/src/templates/terraform/store.env.twig
@@ -7,3 +7,4 @@ export SPRYKER_FE_HOST={{ endpointMap[storeName]['yves'] | default('')  | split(
 export SPRYKER_API_HOST={{ endpointMap[storeName]['glue'] | default('') | split(':') | first | env_var }}
 export SPRYKER_BE_HOST={{ endpointMap[storeName]['backoffice'] | default('')  | split(':') | first | env_var }}
 export SPRYKER_SSL_ENABLE="{{ project['docker']['ssl']['enabled'] ? 1 : 0}}"
+export SPRYKER_ACTIVE_STORES={{ project['regions'][regionName]['stores'] | keys | join(',') | env_var }}


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-7329

<!-- Please, write background  -->

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- Introduced `SPRYKER_ACTIVE_STORES` environment variable which contains the list of active stores per region.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
