### PR TITLE
SC-9184: Force argument for `docker/sdk prune`

### DIFF
--- a/bin/command/internal/prune.sh
+++ b/bin/command/internal/prune.sh
@@ -3,13 +3,21 @@
 Registry::addCommand "prune" "Command::prune"
 
 function Command::prune() {
+	local forceArg=${1}
+
+	if [ "${forceArg}" == "--f" ] || ; then
+		forceArg='-f'
+	else
+		forceArg=''
+	fi
+
     Compose::down
     sync clean # TODO deprecated, use Registry::Flow::addAfterDown in mounts
     Console::error "This will delete ALL docker images and volumes on the host."
-    docker image prune
-    docker volume prune
-    docker system prune -a
-    docker builder prune -a
+    docker image prune ${forceArg}
+    docker volume prune ${forceArg}
+    docker system prune -a ${forceArg}
+    docker builder prune -a ${forceArg}
 
     return "${TRUE}"
 }

--- a/bin/command/internal/prune.sh
+++ b/bin/command/internal/prune.sh
@@ -5,7 +5,7 @@ Registry::addCommand "prune" "Command::prune"
 function Command::prune() {
 	local forceArg=${1}
 
-	if [ "${forceArg}" == "--f" ] || ; then
+	if [ "${forceArg}" == "--f" ]; then
 		forceArg='-f'
 	else
 		forceArg=''


### PR DESCRIPTION
#### Ticket
- https://spryker.atlassian.net/browse/SC-9184

#### Change log

- Introduced `--f` argument in `docker/sdk prune` command for skipping prompt questions.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
