### PR TITLE
SCO-35211: Preserve $request_uri via redirects for `static` application type

### DIFF
--- a/docs/07-deploy-file/02-deploy.file.reference.v1.md
+++ b/docs/07-deploy-file/02-deploy.file.reference.v1.md
@@ -174,7 +174,7 @@ imports:
     parameters:
       {dynamic_parameter_name}: '{dynamic_parameter_value}'
       {dynamic_parameter_name}: '{dynamic_parameter_value}'
-```            
+```
 
 Example:
 ```yaml
@@ -425,6 +425,7 @@ Optional parameters for `application:`:
 * `groups: applications: application: endpoints: endpoint: redirect:` - defines redirect rules.
 * `groups: applications: application: endpoints: endpoint: redirect: code` - defines an HTTP code for a redirect. Allowed values are `301` and `302`.
 * `groups: applications: application: endpoints: endpoint: redirect: url` - defines a URL to redirect to.
+* `groups: applications: application: endpoints: endpoint: redirect: request-uri` - preserves or ignores request-uri due to redirect. Allowed values are `true` or `false`.
 
 * `groups: applications: application: endpoints: real-ip: from:` - defines gateway IP addresses to fetch the real IP address.
 * `groups: applications: application: endpoints: auth:` - defines the basic auth.

--- a/generator/src/templates/nginx/http/static.server.conf.twig
+++ b/generator/src/templates/nginx/http/static.server.conf.twig
@@ -2,7 +2,7 @@
 {% block locations %}
 
 {% if endpointData['redirect'] is not empty %}
-    return {{ endpointData['redirect']['code'] | default(302) }} "{{ endpointData['redirect']['url'] }}$request_uri";
+    return {{ endpointData['redirect']['code'] | default(302) }} "{{ endpointData['redirect']['url'] }}{% if endpointData['redirect']['request-uri'] | default(false) %}$request_uri{% endif %}";
 {% else %}
 
     location / {

--- a/generator/src/templates/nginx/http/static.server.conf.twig
+++ b/generator/src/templates/nginx/http/static.server.conf.twig
@@ -2,7 +2,7 @@
 {% block locations %}
 
 {% if endpointData['redirect'] is not empty %}
-    return {{ endpointData['redirect']['code'] | default(302) }} "{{ endpointData['redirect']['url'] }}";
+    return {{ endpointData['redirect']['code'] | default(302) }} "{{ endpointData['redirect']['url'] }}$request_uri";
 {% else %}
 
     location / {


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SCO-35211

#### Change log

- Fixed the behaviour when `$request_uri` doesn't preserve via redirects for the `static` application type.

### Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
