### PR TITLE
Removed unnecessary double quotes for SPRYKER_JENKINS_CSRF_PROTECTION_ENABLED env variable

### DIFF
--- a/generator/src/templates/terraform/environment.common.tf.twig
+++ b/generator/src/templates/terraform/environment.common.tf.twig
@@ -2,4 +2,4 @@
       SPRYKER_ZED_SSL_ENABLED = {{ ((project['docker']['ssl']['enabled'] | default(false)) ? 1 : 0) | tf_var }}
       SPRYKER_DEBUG_ENABLED = {{ (project['docker']['debug']['enabled'] ? 1 : 0) | tf_var }}
       SPRYKER_ACTIVE_STORES = {{ project['regions'][regionName]['stores'] | keys | join(',') | tf_var }}
-      SPRYKER_JENKINS_CSRF_PROTECTION_ENABLED="{{ (project['services']['scheduler']['csrf-protection-enabled'] ? 1 : 0 ) | tf_var }}"
+      SPRYKER_JENKINS_CSRF_PROTECTION_ENABLED={{ (project['services']['scheduler']['csrf-protection-enabled'] ? 1 : 0 ) | tf_var }}


### PR DESCRIPTION
#### Change log

- fixed double-quotes typo for SPRYKER_JENKINS_CSRF_PROTECTION_ENABLED env variables

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
