### PR TITLE
RN-286: fix log cuts for AWS CloudWatch at 1024 chars

### DIFF
--- a/context/php/php-fpm.d/worker.conf
+++ b/context/php/php-fpm.d/worker.conf
@@ -1,6 +1,6 @@
-; TODO solve issue with different PHP versions. E.g. log_limit, decorate_workers_output are not supported in <= 7.2
-; [global]
-; log_limit = 32768
+[global]
+; limit of aws PutLogEvents https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
+log_limit = 1048576
 
 [worker]
 clear_env = no


### PR DESCRIPTION
### Description

- RN-286: https://spryker.atlassian.net/browse/RN-286

Logs in AWS are cut at 1024 char. There is no way to set this as unlimited, so I put [the limit from aws](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html) for PutLogEvents.

#### Related resources

I requested a confirmation from the PHP team: https://github.com/php/php-src/issues/9010
Eventhough I still don't know why 512.

#### Change log

- fix log cuts for AWS CloudWatch at 1024 chars

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
