### PR TITLE
SC-9864: Add xhprof extension into the php docker containers only for dev environment

### DIFF
--- a/docs/07-deploy-file/02-deploy.file.reference.v1.md
+++ b/docs/07-deploy-file/02-deploy.file.reference.v1.md
@@ -286,6 +286,7 @@ Defines PHP settings for Spryker applications.
   * `blackfire`
   * `newrelic`
   * `tideways`
+  * `xhprof`
 
 ```yaml
 image:
@@ -297,6 +298,7 @@ image:
             - blackfire
             - newrelic
             - tideways
+            - xhprof
 ```
 ***
 


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-9864

#### Related resources

- https://github.com/spryker/docker-php/pull/48

#### Change log

- Updated documentation with new `xhprof` PHP extension.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
