### PR TITLE
SC-10114: NPM library is incompatible with Docker on Mac with Apple chip

### DIFF
--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -24,6 +24,7 @@ RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
      g++ \
      make \
      ; fi'
+
 # Debian contains outdated Yarn package
 RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
     --mount=type=cache,id=aptcache,sharing=locked,target=/var/cache/apt \

--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -20,7 +20,8 @@ RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
      git \
      redis-tools \
      jq \
-     python \
+     python3 \
+     g++ \
      ; fi'
 # Debian contains outdated Yarn package
 RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
@@ -42,6 +43,8 @@ RUN --mount=type=cache,id=apk,sharing=locked,target=/var/cache/apk mkdir -p /etc
      redis \
      yarn \
      jq \
+     python3 \
+     g++ \
      ; fi'
 
 # TODO Not-available feature: autoload-cache. Should be switchable

--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -22,6 +22,7 @@ RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
      jq \
      python3 \
      g++ \
+     make \
      ; fi'
 # Debian contains outdated Yarn package
 RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
@@ -45,6 +46,7 @@ RUN --mount=type=cache,id=apk,sharing=locked,target=/var/cache/apk mkdir -p /etc
      jq \
      python3 \
      g++ \
+     make \
      ; fi'
 
 # TODO Not-available feature: autoload-cache. Should be switchable


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-10114

#### Change log

- added sys packages for npm8 on ARM

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
