### PR TITLE
#Issue-367: Set SPRYKER_DEBUG_PROPEL_ENABLED depending if docker debug is set

### DIFF
--- a/generator/src/templates/env/common.env.twig
+++ b/generator/src/templates/env/common.env.twig
@@ -12,6 +12,7 @@ SPRYKER_LOG_STDERR=php://stderr
 
 {% if project['docker']['debug']['enabled'] %}
 SPRYKER_DEBUG_ENABLED=1
+SPRYKER_DEBUG_PROPEL_ENABLED=1
 {% endif %}
 
 {% if services['blackfire'] %}

--- a/generator/src/templates/terraform/environment.common.tf.twig
+++ b/generator/src/templates/terraform/environment.common.tf.twig
@@ -1,5 +1,6 @@
       APPLICATION_ENV = {{ project['environment'] | tf_var }}
       SPRYKER_ZED_SSL_ENABLED = {{ ((project['docker']['ssl']['enabled'] | default(false)) ? 1 : 0) | tf_var }}
       SPRYKER_DEBUG_ENABLED = {{ (project['docker']['debug']['enabled'] ? 1 : 0) | tf_var }}
+      SPRYKER_DEBUG_PROPEL_ENABLED = {{ (project['docker']['debug']['enabled'] ? 1 : 0) | tf_var }}
       SPRYKER_ACTIVE_STORES = {{ project['regions'][regionName]['stores'] | keys | join(',') | tf_var }}
       SPRYKER_JENKINS_CSRF_PROTECTION_ENABLED={{ (project['services']['scheduler']['csrf-protection-enabled'] ? 1 : 0 ) | tf_var }}


### PR DESCRIPTION
### Description

- Ticket/Issue: https://github.com/spryker/docker-sdk/issues/367

#### Change log

- Set `SPRYKER_DEBUG_PROPEL_ENABLED` environment variable depending if docker debug is set

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
