### PR TITLE
Revert WSL2 case insensitive detection

### DIFF
--- a/bin/platform.sh
+++ b/bin/platform.sh
@@ -2,7 +2,7 @@
 
 function Platform::getPlatform() {
     local uname=$(uname)
-    if [ "${uname}" == "Linux" ] && [ "$(uname -a | grep -c -v -i Microsoft | sed 's/^ *//')" -eq 1 ]; then
+    if [ "${uname}" == "Linux" ] && [ "$(uname -a | grep -c -v Microsoft | sed 's/^ *//')" -eq 1 ]; then
         echo "linux"
         return 0
     fi


### PR DESCRIPTION
#### Change log

- Revert WSL2 case insensitive detection due to synchronization issue on the Windows OS. 

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
