### PR TITLE
SC-11367: FE_HOST and FE_PORT are absent in GLUE_STOREFRONT

### DIFF
--- a/generator/src/templates/nginx/http/glue-storefront.server.conf.twig
+++ b/generator/src/templates/nginx/http/glue-storefront.server.conf.twig
@@ -20,4 +20,9 @@
 {% if storeServices['mail']['sender']['name'] is not empty %}
     fastcgi_param SPRYKER_MAIL_SENDER_NAME "{{ storeServices['mail']['sender']['name'] }}";
 {% endif %}
+
+{% if project['_endpointMap'][endpointData['store']]['yves'] is not empty %}
+        fastcgi_param SPRYKER_FE_HOST "{{ (project['_endpointMap'][endpointData['store']]['yves'] | split(':'))[0] | default('') }}";
+        fastcgi_param SPRYKER_FE_PORT "{{ (project['_endpointMap'][endpointData['store']]['yves'] | split(':'))[1] | default(project['_defaultPort']) }}";
+{% endif %}
 {% endblock location %}


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-11367

#### Change log

### Bugfixes

- Updated GLUE_STOREFRONT application with FE_HOST and FE_PORT.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
