### PR TITLE
SC-11365 On Linux systems docker-compose is not found when docker com…

### DIFF
--- a/bin/environment/docker-compose.sh
+++ b/bin/environment/docker-compose.sh
@@ -3,7 +3,7 @@
 export COMPOSE_HTTP_TIMEOUT=400
 export COMPOSE_CONVERT_WINDOWS_PATHS=1
 
-require docker-compose tr
+require tr
 
 function Environment::checkDockerComposeVersion() {
     Console::verbose::start "Checking docker-compose version..."

--- a/bin/sdk/compose.sh
+++ b/bin/sdk/compose.sh
@@ -2,7 +2,7 @@
 
 # shellcheck disable=SC2155
 
-require docker docker-compose tr awk wc sed grep
+require docker tr awk wc sed grep
 
 Registry::Flow::addBoot "Compose::verboseMode"
 


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-11365


### Change logs

#### Bugfixes
- Fixed the behaviour when DockerSDK expects installed `docker-compose V1`.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
