### PR TITLE
SC-11366: docker/sdk reset command fails to run transfer:generate

### DIFF
--- a/bin/sdk/compose.sh
+++ b/bin/sdk/compose.sh
@@ -136,6 +136,10 @@ function Compose::up() {
 
     Registry::Flow::runBeforeUp
 
+    if [ "${doBuild}" = "--force" ]; then
+      Compose::cleanSourceDirectory
+    fi
+
     Images::buildApplication ${noCache} ${doBuild}
     Codebase::build ${noCache} ${doBuild}
     Assets::build ${noCache} ${doAssets}
@@ -203,4 +207,14 @@ function Compose::cleanEverything() {
     Console::verbose "${INFO}Stopping and removing all Spryker containers and volumes${NC}"
     Compose::command down -v --remove-orphans --rmi all
     Registry::Flow::runAfterDown
+}
+
+function Compose::cleanSourceDirectory() {
+  local projectPath
+  local srcGeneratedPath='src/Generated'
+
+  projectPath=$(pwd)
+  if [ -d "${projectPath}/${srcGeneratedPath}" ]; then
+      rm -rf "${projectPath}/${srcGeneratedPath}"
+  fi
 }


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-11366

#### Change log

- Adjusted up command with cleanup `src/Generated` directory 

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
