### PR TITLE
SC-11973 CI. Replace PHP 7.4 with PHP 8.1

### DIFF
--- a/.github/workflows/b2b-b2c-demo-shop-tests.yml
+++ b/.github/workflows/b2b-b2c-demo-shop-tests.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         platform-image: [
-          'spryker/php:7.4-alpine3.14',
-          'spryker/php:7.4-debian'
+          'spryker/php:8.1-alpine3.16',
+          'spryker/php:8.1-debian'
         ]
         application-store: [ 'DE' ]
         env: [
@@ -52,8 +52,8 @@ jobs:
       fail-fast: false
       matrix:
         platform-image: [
-          'spryker/php:7.4-alpine3.15',
-          'spryker/php:7.4-debian-buster'
+          'spryker/php:8.1-alpine3.16',
+          'spryker/php:8.1-debian'
         ]
         application-store: [ 'DE' ]
         env: [

--- a/.github/workflows/deploy-file-builder-tests.yml
+++ b/.github/workflows/deploy-file-builder-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ 7.4 ]
+        php-version: [ 8.1 ]
     name: Deploy file builder tests
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-11973

#### Change log

Replace PHP 7.4 with PHP 8.1 into CI

- update platform images for functional tests to **spryker/php:8.1-alpine3.16** and **spryker/php:8.1-debian** 
- update platform images for glue tests to **spryker/php:8.1-alpine3.16** and **spryker/php:8.1-debian**

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
