### PR TITLE
Fix WSL XDEBUG IP Detection

### DIFF
--- a/bin/environment/docker.sh
+++ b/bin/environment/docker.sh
@@ -55,13 +55,25 @@ function Environment::getDockerIp() {
 }
 
 # ------------------
+function Environment::isWSL() {
+    # See https://github.com/microsoft/WSL/issues/423#issuecomment-221627364
+    if grep -sqi microsoft /proc/sys/kernel/osrelease; then
+        return "${TRUE}"
+    fi
+
+    return "${FALSE}"
+}
+
+# ------------------
 function Environment::getHostIp() {
 
     local myIp='host.docker.internal'
 
     case ${_PLATFORM} in
         linux)
-            myIp=$(ip route get 1 | sed 's/^.*src \([^ ]*\).*$/\1/;q')
+            if ! Environment::isWSL; then
+                myIp=$(ip route get 1 | sed 's/^.*src \([^ ]*\).*$/\1/;q')
+            fi
             ;;
         macos)
             if Environment::isDockerMachineActive; then

--- a/generator/src/templates/deploy.bash.twig
+++ b/generator/src/templates/deploy.bash.twig
@@ -160,7 +160,7 @@ readonly SSH_AUTH_SOCK_IN_CLI="$([ -n "${SSH_AUTH_SOCK}" ] && [ -z "${COMPOSER_A
 
 # Global variables
 readonly USER_FULL_ID=$(Environment::getFullUserId)
-readonly SPRYKER_XDEBUG_HOST_IP=$(Environment::getHostIp)
+readonly SPRYKER_XDEBUG_HOST_IP="$([ "${SPRYKER_XDEBUG_HOST_IP}" != '' ] && echo ${SPRYKER_XDEBUG_HOST_IP} || echo $(Environment::getHostIp))"
 readonly SECRETS_ENVIRONMENT=("COMPOSER_AUTH='${COMPOSER_AUTH}'")
 
 command=${1}

--- a/generator/src/templates/deploy.bash.twig
+++ b/generator/src/templates/deploy.bash.twig
@@ -160,7 +160,7 @@ readonly SSH_AUTH_SOCK_IN_CLI="$([ -n "${SSH_AUTH_SOCK}" ] && [ -z "${COMPOSER_A
 
 # Global variables
 readonly USER_FULL_ID=$(Environment::getFullUserId)
-readonly SPRYKER_XDEBUG_HOST_IP="$([ "${SPRYKER_XDEBUG_HOST_IP}" != '' ] && echo ${SPRYKER_XDEBUG_HOST_IP} || echo $(Environment::getHostIp))"
+readonly SPRYKER_XDEBUG_HOST_IP=$(Environment::getHostIp)
 readonly SECRETS_ENVIRONMENT=("COMPOSER_AUTH='${COMPOSER_AUTH}'")
 
 command=${1}


### PR DESCRIPTION
### Description

This PR fixes xdebug within Windows WSL systems 

Within Windows WSL systems, the env variable SPRYKER_XDEBUG_HOST_IP is not set correctly. For xdebug to work, the value should be host.docker.internal

This is a known issue

Another branch with an attempted fix exists, https://github.com/spryker/docker-sdk/tree/custom-xdebug-host-ip but this PR has been stale for quite some time. The difference between that Fix, and mine, is that with my fix everything works, and NO extra variables, or changes to the deploy file is introduced, making the change quite simple to understand

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
