### PR TITLE
Enable pcov extension in the cli container

### DIFF
--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -50,6 +50,14 @@ RUN --mount=type=cache,id=apk,sharing=locked,target=/var/cache/apk mkdir -p /etc
      make \
      ; fi'
 
+# Install pcov extension for PHP, enabling fast code coverage reports
+ENV COVERAGE_DRIVER=$COVERAGE_DRIVER
+RUN bash -c 'if [ "${COVERAGE_DRIVER}" == "pcov" ]; then \
+      apk add autoconf && \
+      pecl install pcov && \
+      docker-php-ext-enable pcov \
+      ; fi'
+
 # TODO Not-available feature: autoload-cache. Should be switchable
 #RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache \
 #    chown spryker:spryker /home/spryker/.composer/cache && chmod 0777 /home/spryker/.composer/cache


### PR DESCRIPTION
### Description

At Aldi we are using sonarcube to generate code coverage reports. Currently we are using the xdebug driver, which is really slow. The coverage fails because of memory limit, timeouts and if it does not fail it takes many hours.
The pcov driver generates the same xml report, but much faster. I found a way to enable the pcov php extension for the ci environment only, by introducing an environment variable COVERAGE_DRIVER.

If the COVERAGE_DRIVER is set to "pcov", Dockerfile for the cli image will install pcov and enable the php extension. In any other case, the behaviour will remain as it currently is, using xdebug.

At Aldi we can enable pcov by setting the env variable in the corresponding deploy.yml file.

#### Change log

Added php-ext-pcov to cli image
`images/common/cli/Dockerfile`

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
