### PR TITLE
[DOCS] Replaces boot with bootstrap in docs

### DIFF
--- a/docs/01-quick-start-guide.md
+++ b/docs/01-quick-start-guide.md
@@ -37,7 +37,7 @@ To set up a developer environment:
 1. Bootstrap docker setup, build and start the instance:
 
 ```bash
-docker/sdk boot deploy.dev.yml
+docker/sdk bootstrap deploy.dev.yml
 docker/sdk up
 ```
 
@@ -45,7 +45,7 @@ docker/sdk up
 
 ```bash
 git checkout {your_branch}
-docker/sdk boot deploy.dev.yml
+docker/sdk bootstrap deploy.dev.yml
 docker/sdk up --build --assets --data
 ```
 
@@ -62,7 +62,7 @@ To set up a production-like environment:
 1. Bootstrap docker setup, build and start the instance:
 
 ```bash
-docker/sdk boot deploy.*.yml
+docker/sdk bootstrap deploy.*.yml
 docker/sdk up
 ```
 

--- a/docs/06-configuring-services.md
+++ b/docs/06-configuring-services.md
@@ -71,7 +71,7 @@ services:
 
 2. Bootstrap the docker setup, regenerate demo data, and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml
+docker/sdk bootstrap deploy.*.yml
 docker/sdk clean-data
 docker/sdk up --build --data
 ```
@@ -97,7 +97,7 @@ services:
 ```
 2. Bootstrap the docker setup, regenerate demo data, and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml
+docker/sdk bootstrap deploy.*.yml
 docker/sdk clean-data
 docker/sdk up --build --data
 ```
@@ -123,7 +123,7 @@ services:
 ```
 2. Bootstrap the docker setup, regenerate demo data, and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml
+docker/sdk bootstrap deploy.*.yml
 docker/sdk clean-data
 docker/sdk up --build --data
 ```
@@ -150,7 +150,7 @@ services:
 
 2. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 
 ## OpenSearch
@@ -171,7 +171,7 @@ services:
 
 2. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -201,7 +201,7 @@ echo "127.0.0.1 {custom_endpoint}" | sudo tee -a /etc/hosts
 
 3. 2. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -225,7 +225,7 @@ services:
 
 2. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -260,7 +260,7 @@ echo "127.0.0.1 {custom_endpoint}" | sudo tee -a /etc/hosts
 
 3. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 ## Redis
@@ -283,7 +283,7 @@ services:
 
 2. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -312,7 +312,7 @@ echo "127.0.0.1 {custom_endpoint}" | sudo tee -a /etc/hosts
 
 3. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -343,7 +343,7 @@ services:
 ```
 2. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -380,7 +380,7 @@ services:
 
 3. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -428,7 +428,7 @@ You can pass the server details only with the `docker/sdk up` command.
 
 5. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -519,7 +519,7 @@ image:
 
 3. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -528,7 +528,7 @@ docker/sdk up
 
 By default, in the New Relic dashboard, the APM is displayed as `company-staging-newrelic-app`. To improve visibility, you may want to configure each application as a separate APM. For example, `YVES-DE (docker.dev)`.
 
-To do it, adjust the Monitoring service in `src/Pyz/Service/Monitoring/MonitoringDependencyProvider.php`:  
+To do it, adjust the Monitoring service in `src/Pyz/Service/Monitoring/MonitoringDependencyProvider.php`:
 
 ```php
 <?php declare(strict_types = 1);
@@ -574,7 +574,7 @@ With `new \SprykerEco\Service\NewRelic\Plugin\NewRelicMonitoringExtensionPlugin(
 
 4. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -630,7 +630,7 @@ dashboard:
 
 2. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```
 
@@ -652,6 +652,6 @@ tideways:
 
 2. Bootstrap the docker setup and rebuild the application:
 ```bash
-docker/sdk boot deploy.*.yml &&\
+docker/sdk bootstrap deploy.*.yml &&\
 docker/sdk up
 ```

--- a/docs/09-troubleshooting.md
+++ b/docs/09-troubleshooting.md
@@ -105,7 +105,7 @@ image:
 
 2. Fetch the changes and start the instance:
 ```bash
-docker/sdk boot && docker/sdk up
+docker/sdk bootstrap && docker/sdk up
 ```
 
 ### Demo data was imported incorrectly
@@ -391,7 +391,7 @@ $config[SchedulerJenkinsConstants::JENKINS_CONFIGURATION] = [
 ```
 
 **when**
-Assets install error 
+Assets install error
 ```bash
 line 1: run-s: not found
 ```
@@ -399,4 +399,4 @@ line 1: run-s: not found
 **then**
 1. ensure you are using latest docker-sdk and spryker/php image.
 2. run `docker/sdk pull`
-3. run `docker/sdk boot {{your deploy file}} && docker/sdk up --build`
+3. run `docker/sdk bootstrap {{your deploy file}} && docker/sdk up --build`


### PR DESCRIPTION
### Description

Replaces `docker/sdk boot` with `docker/sdk bootstrap` to use everywhere the same command.

#### Related resources

-

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- Standardize the use of `docker/sdk bootstrap` in the docs 

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
