### PR TITLE
Added merchant portal url and port to MP configuration

### DIFF
--- a/generator/src/templates/nginx/http/merchant-portal.server.conf.twig
+++ b/generator/src/templates/nginx/http/merchant-portal.server.conf.twig
@@ -31,4 +31,9 @@
         fastcgi_param SPRYKER_API_HOST "{{ (project['_endpointMap'][endpointData['store']]['glue'] | split(':'))[0] | default('') }}";
         fastcgi_param SPRYKER_API_PORT "{{ (project['_endpointMap'][endpointData['store']]['glue'] | split(':'))[1] | default(project['_defaultPort']) }}";
 {% endif %}
+
+{% if project['_endpointMap'][endpointData['store']]['merchant-portal'] is not empty %}
+    fastcgi_param SPRYKER_MP_HOST "{{ (project['_endpointMap'][endpointData['store']]['merchant-portal'] | split(':'))[0] | default('') }}";
+    fastcgi_param SPRYKER_MP_PORT "{{ (project['_endpointMap'][endpointData['store']]['merchant-portal'] | split(':'))[1] | default(project['_defaultPort']) }}";
+{% endif %}
 {% endblock location %}


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SLA-2788

In one of our demo shops, we enabled create merchant users through the merchant portal but the reset mail password is being sent with an incorrect URL because the merchant portal URL is not included in mp generator 

#### Related resources

<!-- Reference all related PRs or other resources -->

- <!-- URL_HERE -->

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- <!-- Please, add all changes one by one. E.g "Adjusted something", "Removed something"... -->

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
