### PR TITLE
GlueBackend and GlueStorefront CORS environment variables

### DIFF
--- a/generator/src/templates/nginx/http/glue-backend.server.conf.twig
+++ b/generator/src/templates/nginx/http/glue-backend.server.conf.twig
@@ -16,7 +16,7 @@
     fastcgi_param SPRYKER_GLUE_BACKEND_PORT "{{ externalPort }}";
     fastcgi_param SPRYKER_GLUE_BACKEND_APPLICATION_CORS_ALLOW_ORIGIN "{{ endpointData['cors-allow-origin'] | default('') | nginx_var }}";
 
-    {% if storeServices['mail']['sender']['email'] is not empty %}
+{% if storeServices['mail']['sender']['email'] is not empty %}
     fastcgi_param SPRYKER_MAIL_SENDER_EMAIL "{{ storeServices['mail']['sender']['email'] }}";
 {% endif %}
 {% if storeServices['mail']['sender']['name'] is not empty %}

--- a/generator/src/templates/nginx/http/glue-backend.server.conf.twig
+++ b/generator/src/templates/nginx/http/glue-backend.server.conf.twig
@@ -14,8 +14,9 @@
     fastcgi_param SPRYKER_SESSION_BE_NAMESPACE "{{ storeServices['session']['namespace'] | default(endpointData['services']['session']['namespace']) }}";
     fastcgi_param SPRYKER_GLUE_BACKEND_HOST "{{ host }}";
     fastcgi_param SPRYKER_GLUE_BACKEND_PORT "{{ externalPort }}";
+    fastcgi_param SPRYKER_GLUE_BACKEND_APPLICATION_CORS_ALLOW_ORIGIN "{{ endpointData['cors-allow-origin'] | default('') | nginx_var }}";
 
-{% if storeServices['mail']['sender']['email'] is not empty %}
+    {% if storeServices['mail']['sender']['email'] is not empty %}
     fastcgi_param SPRYKER_MAIL_SENDER_EMAIL "{{ storeServices['mail']['sender']['email'] }}";
 {% endif %}
 {% if storeServices['mail']['sender']['name'] is not empty %}

--- a/generator/src/templates/nginx/http/glue-storefront.server.conf.twig
+++ b/generator/src/templates/nginx/http/glue-storefront.server.conf.twig
@@ -13,8 +13,9 @@
     fastcgi_param SPRYKER_GLUE_STOREFRONT_HOST "{{ host }}";
     fastcgi_param SPRYKER_GLUE_STOREFRONT_PORT "{{ externalPort }}";
     fastcgi_param SPRYKER_GLUE_APPLICATION_CORS_ALLOW_ORIGIN "{{ endpointData['cors-allow-origin'] | default('') | nginx_var }}";
+    fastcgi_param SPRYKER_GLUE_STOREFRONT_APPLICATION_CORS_ALLOW_ORIGIN "{{ endpointData['cors-allow-origin'] | default('') | nginx_var }}";
 
-{% if storeServices['mail']['sender']['email'] is not empty %}
+    {% if storeServices['mail']['sender']['email'] is not empty %}
     fastcgi_param SPRYKER_MAIL_SENDER_EMAIL "{{ storeServices['mail']['sender']['email'] }}";
 {% endif %}
 {% if storeServices['mail']['sender']['name'] is not empty %}

--- a/generator/src/templates/nginx/http/glue-storefront.server.conf.twig
+++ b/generator/src/templates/nginx/http/glue-storefront.server.conf.twig
@@ -15,7 +15,7 @@
     fastcgi_param SPRYKER_GLUE_APPLICATION_CORS_ALLOW_ORIGIN "{{ endpointData['cors-allow-origin'] | default('') | nginx_var }}";
     fastcgi_param SPRYKER_GLUE_STOREFRONT_APPLICATION_CORS_ALLOW_ORIGIN "{{ endpointData['cors-allow-origin'] | default('') | nginx_var }}";
 
-    {% if storeServices['mail']['sender']['email'] is not empty %}
+{% if storeServices['mail']['sender']['email'] is not empty %}
     fastcgi_param SPRYKER_MAIL_SENDER_EMAIL "{{ storeServices['mail']['sender']['email'] }}";
 {% endif %}
 {% if storeServices['mail']['sender']['name'] is not empty %}


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-12536

#### Change log

- Introduced `SPRYKER_GLUE_BACKEND_APPLICATION_CORS_ALLOW_ORIGIN` to store `cors-allow-origin` for `GlueBackend` application.
- Introduced `SPRYKER_GLUE_STOREFRONT_APPLICATION_CORS_ALLOW_ORIGIN ` to store `cors-allow-origin` for `GLUE_STOREFRONT` application.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
