### PR TITLE
Add Host header to proxy_pass

### DIFF
--- a/generator/src/templates/nginx/http/proxy/reverse-proxy.conf.twig
+++ b/generator/src/templates/nginx/http/proxy/reverse-proxy.conf.twig
@@ -4,6 +4,7 @@ location {{ location }} {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
 
         proxy_pass {{ proxy_pass }};
     }


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-12559
- 
#### Change log

- **proxy_set_header Host $http_host;** was added to the reverse-proxy.conf.twig

### Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
