### PR TITLE
Fixed: Gateway container runs regardless CLI containers is not ready yet

### DIFF
--- a/generator/src/templates/nginx/http/gateway/glue.server.conf.twig
+++ b/generator/src/templates/nginx/http/gateway/glue.server.conf.twig
@@ -7,6 +7,9 @@
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         proxy_set_header X-SCHEMA-BASE-URL $scheme://$host;
-        proxy_pass http://cli:9000/glueSchema/;
+        
+        resolver 127.0.0.11 valid=10s;
+        set $cli_proxy_pass http://cli:9000/glueSchema/;
+        proxy_pass $cli_proxy_pass;
     }
 {% endblock locations %}

--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -69,7 +69,8 @@ COPY --chown=spryker:spryker cli /home/spryker/bin
 RUN find /home/spryker/bin -type f -exec chmod +x {} \;
 ENV PATH=/home/spryker/bin:$PATH
 
-RUN mkdir -p /home/spryker/ssh-relay/ && chmod 777 /home/spryker/ssh-relay && touch /home/spryker/ssh-relay/ssh-auth.sock && chmod 666 /home/spryker/ssh-relay/ssh-auth.sock
+RUN mkdir -p /home/spryker/ssh-relay/ && chmod 777 /home/spryker/ssh-relay && touch /home/spryker/ssh-relay/ssh-auth.sock && chmod 666 /home/spryker/ssh-relay/ssh-auth.sock \
+  && touch /tmp/stdout && touch /tmp/stderr && chmod 666 /tmp/stdout && chmod 666 /tmp/stderr
 
 RUN mkdir -p /home/spryker/history && touch /home/spryker/history/.bash_history && chmod 0600 /home/spryker/history/.bash_history
 ENV HISTFILE=/home/spryker/history/.bash_history


### PR DESCRIPTION
### Description

- Ticket/Issue: <!-- Please, point to specific issue or Jira ticket -->

Problem 1. Sometimes within CI CLI container is not still ready when gateway (nginx) container starts. That makes nginx configuration invalid as proxy_pass demands immediate resolving of IP.
```
spryker_ci_gateway_1              /docker-entrypoint.sh ngin ...   Exit 1                                                                                            
                                                                
ubuntu@ip-172-31-20-107:~/build$ docker logs spryker_ci_gateway_1
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/default.conf.template to /etc/nginx/conf.d/default.conf
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
2023/03/21 13:18:05 [emerg] 1#1: host not found in upstream "cli" in /etc/nginx/conf.d/default.conf:293
nginx: [emerg] host not found in upstream "cli" in /etc/nginx/conf.d/default.conf:293
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf differs from the packaged version
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/default.conf.template to /etc/nginx/conf.d/default.conf
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
2023/03/21 13:18:12 [emerg] 1#1: host not found in upstream "cli" in /etc/nginx/conf.d/default.conf:293
nginx: [emerg] host not found in upstream "cli" in /etc/nginx/conf.d/default.conf:293
```
Problem 2. CI tests failed/interrupted without any visible reason. E.g. tests are ok but exit code non-zero.

```
[INIT] Creating fifo: /tmp/stdout
[INIT] Creating fifo: /tmp/stderr
[INIT] Server is running at http://0.0.0.0:9000/
[INIT] Created fifo: /tmp/stdout
[INIT] Created fifo: /tmp/stderr
(node:1) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '/tmp/stdout'
(node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:1) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
[INIT] Piping /tmp/stderr
```

#### Related resources

<!-- Reference all related PRs or other resources -->

- https://github.com/spryker/docker-sdk/blob/5c52f441e41fee70766976a0e4c12b918ab28447/generator/src/templates/nginx/http/gateway/server.conf.twig#L10

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- Adjusted gateway Nginx configuration in the way that resolving of proxy_pass becomes dynamic and does not require running CLI container to be valid
- Fixed missing files error in CLI container that could lead to its termination and flickery command exit code

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
