### PR TITLE
SC-13145 Jenkins backed images doesn't provision "(global)" credentials

### DIFF
--- a/context/jenkins/export/nr-credentials.xml
+++ b/context/jenkins/export/nr-credentials.xml
@@ -1,0 +1,6 @@
+<com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>
+  <scope>GLOBAL</scope>
+  <id>newrelic-insight-key</id>
+  <username>${SPRYKER_NEWRELIC_ACCOUNT_ID}</username>
+  <password>${SPRYKER_NEWRELIC_INSIGHTS_KEY}</password>
+</com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl>

--- a/images/common/services/jenkins/export/Dockerfile
+++ b/images/common/services/jenkins/export/Dockerfile
@@ -40,6 +40,7 @@ RUN bash -c 'if [ ! -z "$(which apt)" ]; then apt update -y && \
 COPY terraform/cli /envs/
 COPY context/jenkins/export/entrypoint.sh /entrypoint.sh
 COPY context/jenkins/export/jenkins.model.JenkinsLocationConfiguration.xml /opt/jenkins.model.JenkinsLocationConfiguration.xml
+COPY context/jenkins/export/nr-credentials.xml /opt/nr-credentials.xml
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-13145

#### Change log

- copied nr-credentials into Jenkins Dockerfile 
- extended entrypoint for Jenkins image with using global credentials

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
