### PR TITLE
SC-13038: Introduced ability to configure Nginx and PHP-FPM timeout options. 

### DIFF
--- a/context/php/php-fpm.d/worker.conf
+++ b/context/php/php-fpm.d/worker.conf
@@ -21,6 +21,6 @@ pm.status_path = /php-fpm-status-worker
 ping.path = /fpm-ping.php
 ping.response = OK
 
-request_terminate_timeout = 1m
+request_terminate_timeout = ${PHP_FPM_REQUEST_TERMINATE_TIMEOUT}
 
 chdir = /

--- a/docs/07-deploy-file/02-deploy.file.reference.v1.md
+++ b/docs/07-deploy-file/02-deploy.file.reference.v1.md
@@ -498,7 +498,39 @@ Optional parameters for `application:`:
 To disable the validation of request body size against this parameter, set it to `0`. We do not recommended disabling it.
 :::
 
+* `groups: applications: application: timeouts: vhost-timeout` - define a common timeout for proxy_connect_timeout, proxy_read_timeout, proxy_send_timeout, fastcgi_send_timeout, fastcgi_read_timeout, client_body_timeout, client_header_timeout, send_timeout, keepalive_timeout. If not specified, the default values apply:
+    * `backoffice` - `1m`
+    * `merchant-portal` - `1m`
+    * `glue-storefront` - `1m`
+    * `glue-backend` - `1m`
+    * `glue` - `1m`
+    * `yves` - `1m`
+```yaml
+...
+    applications:
+        yves:
+        application: yves
+        timeouts:
+            vhost-timeout: 5m
+        ...
+```
 
+* `groups: applications: application: timeouts: request-terminate-timeout` - define the timeout for serving a single request after which the worker process will be killed. If not specified, the default values apply:
+    * `backoffice` - `1m`
+    * `merchant-portal` - `1m`
+    * `glue-storefront` - `1m`
+    * `glue-backend` - `1m`
+    * `glue` - `1m`
+    * `yves` - `1m`
+```yaml
+...
+    applications:
+        yves:
+        application: yves
+        timeouts:
+            request-terminate-timeout: 10m
+        ...
+```
 
 
 

--- a/docs/07-deploy-file/02-deploy.file.reference.v1.md
+++ b/docs/07-deploy-file/02-deploy.file.reference.v1.md
@@ -482,6 +482,23 @@ Optional parameters for `application:`:
             store: STORE-1
  ```
 
+* `groups: applications: application: http: timeout` - define a common timeout for proxy_connect_timeout, proxy_read_timeout, proxy_send_timeout, fastcgi_send_timeout, fastcgi_read_timeout, client_body_timeout, client_header_timeout, send_timeout, keepalive_timeout. If not specified, the default values apply:
+    * `backoffice` - `1m`
+    * `merchant-portal` - `1m`
+    * `glue-storefront` - `1m`
+    * `glue-backend` - `1m`
+    * `glue` - `1m`
+    * `yves` - `1m`
+```yaml
+...
+    applications:
+        yves:
+        application: yves
+        http:
+            timeout: 5m
+        ...
+```
+
 * `groups: applications: application: limits: workers` - defines the maximum number of concurrent child processes a process manager can serve simultaneously.
 
 ```yaml
@@ -498,7 +515,7 @@ Optional parameters for `application:`:
 To disable the validation of request body size against this parameter, set it to `0`. We do not recommended disabling it.
 :::
 
-* `groups: applications: application: timeouts: vhost-timeout` - define a common timeout for proxy_connect_timeout, proxy_read_timeout, proxy_send_timeout, fastcgi_send_timeout, fastcgi_read_timeout, client_body_timeout, client_header_timeout, send_timeout, keepalive_timeout. If not specified, the default values apply:
+* `groups: applications: application: limits: request-terminate-timeout` - define the timeout for serving a single request after which the worker process will be killed. If not specified, the default values apply:
     * `backoffice` - `1m`
     * `merchant-portal` - `1m`
     * `glue-storefront` - `1m`
@@ -510,24 +527,7 @@ To disable the validation of request body size against this parameter, set it to
     applications:
         yves:
         application: yves
-        timeouts:
-            vhost-timeout: 5m
-        ...
-```
-
-* `groups: applications: application: timeouts: request-terminate-timeout` - define the timeout for serving a single request after which the worker process will be killed. If not specified, the default values apply:
-    * `backoffice` - `1m`
-    * `merchant-portal` - `1m`
-    * `glue-storefront` - `1m`
-    * `glue-backend` - `1m`
-    * `glue` - `1m`
-    * `yves` - `1m`
-```yaml
-...
-    applications:
-        yves:
-        application: yves
-        timeouts:
+        limits:
             request-terminate-timeout: 10m
         ...
 ```

--- a/generator/src/templates/env/pm/php-fpm.env.twig
+++ b/generator/src/templates/env/pm/php-fpm.env.twig
@@ -3,5 +3,5 @@ PHP_FPM_PM=static
 PHP_FPM_PM_MAX_CHILDREN={{ applicationData['limits']['workers'] | default(4) }}
 {% endif %}
 
-PHP_FPM_REQUEST_TERMINATE_TIMEOUT={{ applicationData['timeouts']['request-terminate-timeout'] | default('1m') }}
+PHP_FPM_REQUEST_TERMINATE_TIMEOUT={{ applicationData['limits']['request-terminate-timeout'] | default('1m') }}
 

--- a/generator/src/templates/env/pm/php-fpm.env.twig
+++ b/generator/src/templates/env/pm/php-fpm.env.twig
@@ -2,3 +2,6 @@
 PHP_FPM_PM=static
 PHP_FPM_PM_MAX_CHILDREN={{ applicationData['limits']['workers'] | default(4) }}
 {% endif %}
+
+PHP_FPM_REQUEST_TERMINATE_TIMEOUT={{ applicationData['timeouts']['request-terminate-timeout'] | default('1m') }}
+

--- a/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
+++ b/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
@@ -42,7 +42,7 @@ server {
     storeServices: regions[groupData['region']]['stores'][endpointData['store']]['services'] ?? regions[groupData['region']]['services'] | default([]),
     upstream: "${SPRYKER_NGINX_CGI_" ~ (applicationName | upper) ~ "}",
     zedHost: zedHost,
-    timeout: '1m',
+    timeout: applicationData['timeouts']['vhost-timeout'] | default('1m'),
     project: _context,
     regionEndpointMap: _context['regionEndpointMap'][endpointData['identifier']]
 } %}

--- a/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
+++ b/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
@@ -42,7 +42,7 @@ server {
     storeServices: regions[groupData['region']]['stores'][endpointData['store']]['services'] ?? regions[groupData['region']]['services'] | default([]),
     upstream: "${SPRYKER_NGINX_CGI_" ~ (applicationName | upper) ~ "}",
     zedHost: zedHost,
-    timeout: applicationData['timeouts']['vhost-timeout'] | default('1m'),
+    timeout: applicationData['http']['timeout'] | default('1m'),
     project: _context,
     regionEndpointMap: _context['regionEndpointMap'][endpointData['identifier']]
 } %}


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-13038

#### Change log

Was added the ability for configuration:
- `groups: applications: application: http: timeout`
- `groups: applications: application: limits: request-terminate-timeout`

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
