### PR TITLE
SC-15697: Failed to download blackfire

### DIFF
--- a/bin/lib/bool.sh
+++ b/bin/lib/bool.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+function Bool::normalizeBashBool() {
+    case "${1}" in
+        ${TRUE})
+            echo -n 1
+            ;;
+        ${FALSE})
+            echo -n 0
+            ;;
+        *)
+            Console::error "Unknown boolean value \"${1}\". Use \${TRUE} or \${FALSE}."
+            ;;
+    esac
+}

--- a/bin/sdk/images/common.sh
+++ b/bin/sdk/images/common.sh
@@ -2,6 +2,8 @@
 
 require docker
 
+import lib/bool.sh
+
 function Images::pull() {
     docker pull "${SPRYKER_PLATFORM_IMAGE}" || true
 }
@@ -103,13 +105,13 @@ function Images::_buildApp() {
     fi
 
     Console::verbose "${INFO}Building CLI images${NC}"
-
     docker build \
         -t "${baseCliImage}" \
         -t "${pipelineImage}" \
         -f "${DEPLOYMENT_PATH}/images/common/cli/Dockerfile" \
         --progress="${PROGRESS_TYPE}" \
         --build-arg "SPRYKER_PARENT_IMAGE=${localAppImage}" \
+        --build-arg "BLACKFIRE_EXTENSION_ENABLED=$(Bool::normalizeBashBool ${BLACKFIRE_EXTENSION_ENABLED})" \
         "${DEPLOYMENT_PATH}/context" 1>&2
 
     docker build \

--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -3,12 +3,15 @@ ARG SPRYKER_PARENT_IMAGE
 
 FROM ${SPRYKER_PARENT_IMAGE} as cli-basic
 
+ARG BLACKFIRE_EXTENSION_ENABLED=0
+
 # Blackfire client
-RUN mkdir -p /tmp/blackfire \
+RUN bash -c 'if [ ${BLACKFIRE_EXTENSION_ENABLED} = 1 ]; then \
+    mkdir -p /tmp/blackfire \
     && architecture=$(case $(uname -m) in i386 | i686 | x86) echo "i386" ;; x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
-    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/cli/linux/$architecture | tar zxp -C /tmp/blackfire \
+    && wget -qO- -U "Docker" https://blackfire.io/api/v1/releases/cli/linux/$architecture | tar zxp -C /tmp/blackfire \
     && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
-    && rm -Rf /tmp/blackfire
+    && rm -Rf /tmp/blackfire; fi'
 
 ENV PATH=/data/vendor/bin:$PATH
 


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-15697

#### Change log

- adjusted Blackfire client install process in CLI depending on enabling backfire PHP extension
- changed download tool from CURL to Wget for Blackfire client

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
