### PR TITLE
Generates environement.tf application name in lowercase

### DIFF
--- a/generator/src/templates/terraform/environment.tf.twig
+++ b/generator/src/templates/terraform/environment.tf.twig
@@ -3,7 +3,7 @@ locals {
 {% for groupName, groupData in project.groups %}
 {% for applicationName, applicationData in groupData['applications'] %}
 {% if applicationData['application'] != 'static' %}
-    {{ applicationName }} = {
+    {{ applicationName | lower }} = {
 {% include "terraform/application/" ~ (applicationData['application'] | lower) ~ ".tf.twig" with {
     applicationName: applicationName,
     applicationData: applicationData,


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-16432
#### Change log

### Bugfixes

- environement.tf generates with uppercase when only the lowercase is available.

### Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
