### PR TITLE
Сould not build variables_hash, you should increase variables_hash_bucket_size: 64.

### DIFF
--- a/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
+++ b/generator/src/templates/nginx/conf.d/frontend.default.conf.twig
@@ -1,3 +1,4 @@
+variables_hash_bucket_size 128;
 server_names_hash_bucket_size 128;
 server_tokens off;
 


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-17416