### PR TITLE
SC-18436: 4-level domain generation for `internal` endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 
 deployment/*
 !deployment/.gitkeep
-
+.DS_Store

--- a/generator/index.php
+++ b/generator/index.php
@@ -341,13 +341,16 @@ foreach ($projectData['groups'] ?? [] as $groupName => $groupData) {
             ];
         }
 
-        foreach ($applicationData['endpoints'] ?? [] as $endpoint => $endpointData) {
-
+        if (isset($applicationData['endpoints']) && is_array($applicationData['endpoints'])) {
+          foreach ($applicationData['endpoints'] ?? [] as $endpoint => $endpointData) {
+            $internal = isset($endpointData['internal']) && $endpointData['internal'] === true;
             $host = strtok($endpoint, ':');
+            $zone = $internal ? getFrontendZoneByDomainLevel($host, 4) : getFrontendZoneByDomainLevel($host, 2);
+
             $frontend[$host] = [
-                'zone' => getFrontendZoneByDomainLevel($host),
+                'zone' => $zone,
                 'type' => $applicationName,
-                'internal' => (bool)($endpointData['internal'] ?? false),
+                'internal' => $internal,
             ];
 
             $authEngine = $endpointData['auth']['engine'] ?? 'none';
@@ -440,6 +443,7 @@ foreach ($projectData['groups'] ?? [] as $groupName => $groupData) {
             }
 
             $envVarEncoder->setIsActive(false);
+          }
         }
     }
 }


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-18436
https://spryker.atlassian.net/browse/SC-17672

Issue: For internal environments, the current system generates the zone with a 2-level domain instead of a 4-level one. **This has led to additional manual** effort being required on the infrastructure side to override the field.

Current Output:
```
{
    "glue.de.spryker.toys": {
        "zone": "spryker.toys",
        "type": "Glue",
        "internal": true
    },
    "glue.at.spryker.toys": {
        "zone": "spryker.toys",
        "type": "Glue",
        "internal": true
    },
    // ... (other entries)
}
```

Expected Output:
```
{
    "glue.de.yulia-dev.cloud.spryker.toys": {
        "zone": "yulia-dev.cloud.spryker.toys",
        "type": "Glue",
        "internal": true
    },
    "glue.at.yulia-dev.cloud.spryker.toys": {
        "zone": "yulia-dev.cloud.spryker.toys",
        "type": "Glue",
        "internal": true
    },
    // ... (other entries)
}
```

Action Required: Adjust the system to generate the zone with the correct fourth-level domain for internal environments. This will eliminate the need for manual intervention and ensure consistency in the generated output.

#### Change log

SC-18436: Adjusted `zone` generation to 4-level for `internal` endpoints

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
