### PR TITLE
Extend Backend Gateway application with MerchantPortal host and port.

### DIFF
--- a/generator/src/templates/nginx/http/backend-gateway.server.conf.twig
+++ b/generator/src/templates/nginx/http/backend-gateway.server.conf.twig
@@ -32,4 +32,9 @@
         fastcgi_param SPRYKER_API_HOST "{{ (project['_endpointMap'][endpointData['identifier']]['glue'] | split(':'))[0] | default('') }}";
         fastcgi_param SPRYKER_API_PORT "{{ (project['_endpointMap'][endpointData['identifier']]['glue'] | split(':'))[1] | default(project['_defaultPort']) }}";
     {% endif %}
+
+    {% if project['_endpointMap'][endpointData['identifier']]['merchant-portal'] is not empty %}
+        fastcgi_param SPRYKER_MP_HOST "{{ (project['_endpointMap'][endpointData['identifier']]['merchant-portal'] | split(':'))[0] | default('') }}";
+        fastcgi_param SPRYKER_MP_PORT "{{ (project['_endpointMap'][endpointData['identifier']]['merchant-portal'] | split(':'))[1] | default(project['_defaultPort']) }}";
+    {% endif %}
 {% endblock location %}


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/CC-32874

During the creation of MR request, we have a requirement to send emails to merchant.
This mail should contain a link from the merchant portal app, unf, `backend-gateway` app doesn't contain `SPRYKER_MP_HOST` env. 

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- Extended `backend-gateway` Nginx configuration with `merchant-portal` fastcgi params: `SPRYKER_MP_HOST`  and `SPRYKER_MP_PORT` if `merchant-portal` application is defined.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
