### PR TITLE
Bump the default version of the Jenkins service

### DIFF
--- a/generator/src/templates/service/jenkins/default/jenkins.yml.twig
+++ b/generator/src/templates/service/jenkins/default/jenkins.yml.twig
@@ -1,1 +1,1 @@
-{% include "service/#{engine}/2.176/#{engine}.yml.twig" with _context only %}
+{% include "service/#{engine}/2.442/#{engine}.yml.twig" with _context only %}


### PR DESCRIPTION
### Description

If Jenkins version isn't specified in the deploy file, the build will fail for ARM envs with next error message:

> Running generator 
> Service version compatibility errors:
>  * `scheduler` service with `jenkins` engine and 2.176 version are unsupported on ARM architecture.
> Please check documentation.

#### Change log

Bumped Jenkins default version.

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
