### PR TITLE
Update docker-compose.yml.twig

### DIFF
--- a/bin/command/install/bootstrap.sh
+++ b/bin/command/install/bootstrap.sh
@@ -106,11 +106,15 @@ function Command::bootstrap() {
     if [ "${USER_FULL_ID%%:*}" != '0' ]; then
         userToRun=()
     fi
+
+    local dockerVersion=`docker version --format json`
+
     docker run -i --rm "${userToRun[@]}" \
         -e SPRYKER_PLATFORM_IMAGE="${SPRYKER_PLATFORM_IMAGE:-""}" \
         -e SPRYKER_DOCKER_SDK_PLATFORM="${_PLATFORM}" \
         -e SPRYKER_DOCKER_SDK_DEPLOYMENT_DIR="${DESTINATION_DIR}" \
         -e VERBOSE="${VERBOSE}" \
+        -e DOCKER_VERSION="${dockerVersion}" \
         -v "${tmpDeploymentDir}":/data/deployment:rw \
         spryker_docker_sdk
 

--- a/generator/index.php
+++ b/generator/index.php
@@ -104,6 +104,10 @@ $projectData['_requirementAnalyzerData'] = buildDataForRequirementAnalyzer($proj
 $projectData['secrets'] = buildSecrets($deploymentDir);
 $projectData = buildDefaultCredentials($projectData);
 
+$dockerVersionObject = json_decode(getenv('DOCKER_VERSION', '{}'));
+$skipVersionHeader = version_compare($dockerVersionObject?->Client?->Version, '26.0.0', '>=');
+$projectData['_skipVersionHeader'] = $skipVersionHeader;
+
 // TODO Make it optional in next major
 // Making webdriver as required service for BC reasons
 // todo: waitFor refactoring dependency + document + testing mode

--- a/generator/src/templates/docker-compose.yml.twig
+++ b/generator/src/templates/docker-compose.yml.twig
@@ -1,3 +1,6 @@
+{% if not _skipVersionHeader %}
+version: "3.7"
+{% endif %}
 
 x-volumes:
   &app-volumes

--- a/generator/src/templates/docker-compose.yml.twig
+++ b/generator/src/templates/docker-compose.yml.twig
@@ -1,4 +1,3 @@
-version: "3.7"
 
 x-volumes:
   &app-volumes


### PR DESCRIPTION
### Description

Removing version because of changes in docker version 25.05 does not require "version" anymore. This results in warnings during the startup

#### Related resources

#### Change log

Removed version line in docker-compose twig template

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
