### PR TITLE
fix docker engine provoking failed frontend nginx SPRYKER_DNS_RESOLVER_IP

### DIFF
--- a/generator/src/templates/nginx/entrypoint.sh.twig
+++ b/generator/src/templates/nginx/entrypoint.sh.twig
@@ -12,7 +12,7 @@ export SPRYKER_NGINX_CGI_{{ applicationName | upper}}=${SPRYKER_NGINX_CGI_{{ (ap
 envsubst '{{ envVariables | join(' ') }}' < /etc/nginx/template/default.conf.tmpl > /etc/nginx/conf.d/default.conf
 
 if [ -z "${SPRYKER_DNS_RESOLVER_IP}" ]; then
-    export SPRYKER_DNS_RESOLVER_IP=$(grep "nameserver" /etc/resolv.conf | awk '{print $2}')
+    export SPRYKER_DNS_RESOLVER_IP=$(grep "^\s*nameserver " /etc/resolv.conf | awk '{print $2}')
 fi
 
 envsubst '$SPRYKER_DNS_RESOLVER_IP ${SPRYKER_DNS_RESOLVER_FLAGS} {{ envVariables | join(' ') }}' < /etc/nginx/template/resolver.conf.tmpl > /etc/nginx/conf.d/00-resolver.conf


### PR DESCRIPTION
### Description

Starting the frontend service fails with: 
`invalid port in resolver "Overrides:" in /etc/nginx/conf.d/00-resolver.conf:2`

lines containing `# Overrides: [nameservers]`
would be grepped due to unspecific keyword selection e.g. when using fritz.box and docker engine
![docker-sdk-frontend-entrypoint](https://github.com/spryker/docker-sdk/assets/52067443/f2762b10-7385-4d75-a74f-d8a59e50f471)

#### Related resources

none

#### Change log

fix SPRYKER_DNS_RESOLVER_IP fallback to be more robust against malformed host resolv.conf files

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
