### PR TITLE
Add DB support for MariaDB version 10.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,41 +54,42 @@ For contribution guidelines, see [Code contribution guide](https://docs.spryker.
 
 ## Supported services
 
-| Service         | Engine       | Version(s)   | ARM support | Note                               |
-|-----------------|--------------|--------------|-------------|------------------------------------|
-| database        | postgres     | 9.6*         | &check;     |                                    |
-|                 |              | 10           | &check;     |                                    |
-|                 |              | 11           | &check;     |                                    |
-|                 |              | 12           | &check;     |                                    |
-|                 | mysql        | 5.7          |             |                                    |
-|                 |              | mariadb-10.2 | &check;     | https://endoflife.date/mariadb     |
-|                 |              | mariadb-10.3 | &check;     | https://endoflife.date/mariadb     |
-|                 |              | mariadb-10.4 | &check;     |                                    |
-|                 |              | mariadb-10.5 | &check;     |                                    |
-|                 |              | mariadb-10.6 | &check;     |                                    |
-| broker          | rabbitmq     | 3.7          |             |                                    |
-|                 |              | 3.8          | &check;     |                                    |
-|                 |              | 3.9          | &check;     |                                    |
-| session         | redis        | 5.0*         | &check;     |                                    |
-|                 | redis        | 6.2          | &check;     |                                    |
-| key_value_store | redis        | 5.0*         | &check;     |                                    |
-|                 | redis        | 6.2          | &check;     |                                    |
-| search          | elastic      | 5.6*         | &check;     | https://www.elastic.co/support/eol |
-|                 |              | 6.8          | &check;     | https://www.elastic.co/support/eol |
-|                 |              | 7.6          | &check;     |                                    |
-|                 |              | 7.10         | &check;     |                                    |
-|                 | opensearch   | 1.3          | &check;     |                                    |
-| scheduler       | jenkins      | 2.176        |             |                                    |
-|                 |              | 2.305        | &check;     |                                    |
-|                 |              | 2.324        | &check;     |                                    |
-|                 |              | 2.401        | &check;     |                                    |
-|                 |              | 2.442        | &check;     |                                    |
-| webdriver       | phantomjs    | latest*      |             |                                    |
-|                 | chromedriver | latest       | &check;     |                                    |
-| mail_catcher    | mailhog      | 1.0          | &check;     |                                    |
-| swagger         | swagger-ui   | v3.24        | &check;     |                                    |
-| kibana          | kibana       | 5.6*         | &check;     | https://www.elastic.co/support/eol |
-|                 |              | 6.8          | &check;     | https://www.elastic.co/support/eol |
-|                 |              | 7.6          | &check;     |                                    |
-|                 |              | 7.10         | &check;     |                                    |
-| blackfire       | blackfire    | latest       | &check;     |                                    |
+| Service         | Engine       | Version(s)    | ARM support | Note                               |
+|-----------------|--------------|---------------|-------------|------------------------------------|
+| database        | postgres     | 9.6*          | &check;     |                                    |
+|                 |              | 10            | &check;     |                                    |
+|                 |              | 11            | &check;     |                                    |
+|                 |              | 12            | &check;     |                                    |
+|                 | mysql        | 5.7           |             |                                    |
+|                 |              | mariadb-10.2  | &check;     | https://endoflife.date/mariadb     |
+|                 |              | mariadb-10.3  | &check;     | https://endoflife.date/mariadb     |
+|                 |              | mariadb-10.4  | &check;     |                                    |
+|                 |              | mariadb-10.5  | &check;     |                                    |
+|                 |              | mariadb-10.6  | &check;     |                                    |
+|                 |              | mariadb-10.11 | &check;     |                                    |
+| broker          | rabbitmq     | 3.7           |             |                                    |
+|                 |              | 3.8           | &check;     |                                    |
+|                 |              | 3.9           | &check;     |                                    |
+| session         | redis        | 5.0*          | &check;     |                                    |
+|                 | redis        | 6.2           | &check;     |                                    |
+| key_value_store | redis        | 5.0*          | &check;     |                                    |
+|                 | redis        | 6.2           | &check;     |                                    |
+| search          | elastic      | 5.6*          | &check;     | https://www.elastic.co/support/eol |
+|                 |              | 6.8           | &check;     | https://www.elastic.co/support/eol |
+|                 |              | 7.6           | &check;     |                                    |
+|                 |              | 7.10          | &check;     |                                    |
+|                 | opensearch   | 1.3           | &check;     |                                    |
+| scheduler       | jenkins      | 2.176         |              |                                    |
+|                 |              | 2.305         | &check;     |                                    |
+|                 |              | 2.324         | &check;     |                                    |
+|                 |              | 2.401         | &check;     |                                    |
+|                 |              | 2.442         | &check;     |                                    |
+| webdriver       | phantomjs    | latest*       |             |                                    |
+|                 | chromedriver | latest        | &check;     |                                    |
+| mail_catcher    | mailhog      | 1.0           | &check;     |                                    |
+| swagger         | swagger-ui   | v3.24         | &check;     |                                    |
+| kibana          | kibana       | 5.6*          | &check;     | https://www.elastic.co/support/eol |
+|                 |              | 6.8           | &check;     | https://www.elastic.co/support/eol |
+|                 |              | 7.6           | &check;     |                                    |
+|                 |              | 7.10          | &check;     |                                    |
+| blackfire       | blackfire    | latest        | &check;     |                                    |

--- a/docs/06-configuring-services.md
+++ b/docs/06-configuring-services.md
@@ -62,7 +62,7 @@ Follow the steps below to switch the database service to MariaDB:
 services:
     database:
         engine: mysql
-        version: mariadb-10.4
+        version: mariadb-10.11
         ...
         endpoints:
             localhost:3306:

--- a/generator/deploy-file-generator/templates/environment/dev/services.deploy.template.yml
+++ b/generator/deploy-file-generator/templates/environment/dev/services.deploy.template.yml
@@ -1,7 +1,7 @@
 services:
     database:
         engine: mysql
-        version: mariadb-10.4
+        version: mariadb-10.11
         endpoints:
             localhost:3306:
                 protocol: tcp

--- a/generator/src/templates/service/mysql/mariadb-10.11/mysql.yml.twig
+++ b/generator/src/templates/service/mysql/mariadb-10.11/mysql.yml.twig
@@ -1,0 +1,19 @@
+  {{ serviceName }}:
+    image: mariadb:10.11
+    networks:
+      - private
+    labels:
+      'spryker.app.name': database
+      'spryker.app.type': services
+      'spryker.project': ${SPRYKER_DOCKER_PREFIX}:${SPRYKER_DOCKER_TAG}
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "--silent"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    environment:
+      MYSQL_ROOT_PASSWORD: "{{ serviceData['root']['password'] }}"
+      LANG: C.UTF-8
+    volumes:
+      - {{ serviceName }}-{{ serviceData['engine'] }}-data:/var/lib/mysql:rw
+      - ./${DEPLOYMENT_PATH}/context/mysql/my.cnf:/etc/mysql/mariadb.conf.d/my.cnf:ro


### PR DESCRIPTION
This is just a short Pull Request which supports a new version of MariaDB (10.11) which is required for our project. 
Would be great to have this in docker/sdk core instead of using a fork