### PR TITLE
Fix generator multi store store specific executor conditions

### DIFF
--- a/generator/project-data/src/DataBuilder/MultiStore/Executor/StoreSpecific/StoreSpecificBrokerExecutor.php
+++ b/generator/project-data/src/DataBuilder/MultiStore/Executor/StoreSpecific/StoreSpecificBrokerExecutor.php
@@ -26,7 +26,7 @@ class StoreSpecificBrokerExecutor implements DataExecutorInterface
         foreach ($projectData[ProjectDataRegionsConstants::REGIONS_KEY] as $regionName => $regionData) {
             $regionServices = $regionData[ProjectDataServicesConstants::SERVICES_KEY] ?? [];
 
-            if (!isset($services[ProjectDataServicesConstants::BROKER_KEY][ProjectDataServicesConstants::SERVICES_NAMESPACE_KEY])) {
+            if (!isset($regionServices[ProjectDataServicesConstants::BROKER_KEY][ProjectDataServicesConstants::SERVICES_NAMESPACE_KEY])) {
                 continue;
             }
 

--- a/generator/project-data/src/DataBuilder/MultiStore/Executor/StoreSpecific/StoreSpecificKeyValueStoreExecutor.php
+++ b/generator/project-data/src/DataBuilder/MultiStore/Executor/StoreSpecific/StoreSpecificKeyValueStoreExecutor.php
@@ -26,7 +26,7 @@ class StoreSpecificKeyValueStoreExecutor implements DataExecutorInterface
         foreach ($projectData[ProjectDataRegionsConstants::REGIONS_KEY] as $regionName => $regionData) {
             $regionServices = $regionData[ProjectDataServicesConstants::SERVICES_KEY] ?? [];
 
-            if (!isset($services[ProjectDataServicesConstants::KEY_VALUE_STORE_KEY][ProjectDataServicesConstants::SERVICES_NAMESPACE_KEY])) {
+            if (!isset($regionServices[ProjectDataServicesConstants::KEY_VALUE_STORE_KEY][ProjectDataServicesConstants::SERVICES_NAMESPACE_KEY])) {
                 continue;
             }
 

--- a/generator/project-data/src/DataBuilder/MultiStore/Executor/StoreSpecific/StoreSpecificSessionExecutor.php
+++ b/generator/project-data/src/DataBuilder/MultiStore/Executor/StoreSpecific/StoreSpecificSessionExecutor.php
@@ -26,7 +26,7 @@ class StoreSpecificSessionExecutor implements DataExecutorInterface
         foreach ($projectData[ProjectDataRegionsConstants::REGIONS_KEY] as $regionName => $regionData) {
             $regionServices = $regionData[ProjectDataServicesConstants::SERVICES_KEY] ?? [];
 
-            if (!isset($services[ProjectDataServicesConstants::SESSION_KEY][ProjectDataServicesConstants::SERVICES_NAMESPACE_KEY])) {
+            if (!isset($regionServices[ProjectDataServicesConstants::SESSION_KEY][ProjectDataServicesConstants::SERVICES_NAMESPACE_KEY])) {
                 continue;
             }
 


### PR DESCRIPTION
### Description

- Ticket/Issue: none

A non-existing structure is examined in a condition that makes its result always true and therefore further processing is skipped

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- Replaced a variable with the existing one in the conditions of the files:
`generator/project-data/src/DataBuilder/MultiStore/Executor/StoreSpecific/StoreSpecificBrokerExecutor.php`
`generator/project-data/src/DataBuilder/MultiStore/Executor/StoreSpecific/StoreSpecificKeyValueStoreExecutor.php`
`generator/project-data/src/DataBuilder/MultiStore/Executor/StoreSpecific/StoreSpecificSessionExecutor.php`

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
