### PR TITLE
SC-21731: Extend Cli image with `py3-setuptools` and `build-base` packages

### DIFF
--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -49,8 +49,10 @@ RUN --mount=type=cache,id=apk,sharing=locked,target=/var/cache/apk mkdir -p /etc
      yarn \
      jq \
      python3 \
+     py3-setuptools \
      g++ \
      make \
+     build-base \
      ; fi'
 
 # TODO Not-available feature: autoload-cache. Should be switchable


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-21731

<!-- Please, write background  -->

#### Change log

- Fix the behavior when the NPM cannot be installed due to the missed `gyp`.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
