### PR TITLE
Downgrades dashboard docker image to nodejs v18

### DIFF
--- a/images/common/dashboard/Dockerfile
+++ b/images/common/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.20 AS dashboard
+FROM node:18-alpine3.20 AS dashboard
 
 RUN mkdir -p /dashboard
 WORKDIR /dashboard


### PR DESCRIPTION
### Description

Downgrades dashboard docker image to nodejs v18 to unblock windows users.

#### Related resources

Relates to #520 and #533 and is meant as intermediate solution. 

 
> [!WARNING]
> Please have in mind that node v18 will not receive security updates after 30 Apr 2025

#### Change log


<!-- Relevant changes. Those will be copied into the release log. -->

- Downgrades docker image for the dashboard from node v22 to node v18 (see #520 and #533)

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
