### PR TITLE
Prefer tideways published docker container over custom container

### DIFF
--- a/images/common/services/tideways/Dockerfile
+++ b/images/common/services/tideways/Dockerfile
@@ -1,15 +1,4 @@
-FROM debian:stable-slim AS tideways-daemon
+FROM ghcr.io/tideways/daemon:latest
 
 ARG TIDEWAYS_ENVIRONMENT_DEFAULT=production
 ENV TIDEWAYS_ENVIRONMENT=$TIDEWAYS_ENVIRONMENT_DEFAULT
-
-RUN apt update -y && apt install -yq --no-install-recommends gnupg2 curl sudo ca-certificates wget
-
-RUN echo 'deb https://packages.tideways.com/apt-packages-main any-version main' > /etc/apt/sources.list.d/tideways.list && \
-    wget -qO - 'https://packages.tideways.com/key.gpg' | apt-key add -
-RUN DEBIAN_FRONTEND=noninteractive apt update -y && apt install -yq tideways-daemon && \
-    apt autoremove --assume-yes && \
-    apt clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ENTRYPOINT ["tideways-daemon","--hostname=tideways","--address=0.0.0.0:9135"]


### PR DESCRIPTION
### Description

We at Tideways started publishing containers for our daemon and PHP extension last year to ensure easier integration in docker setups and to make it easy to keep versions updated

We make available an image supporting mac and Linux on x86 and ARM at: https://github.com/tideways/container-images/pkgs/container/daemon
 
This PR uses that image over the classic install way via apt. It's faster and will ensure up to do date versions easier and in a more docker supported way.

The effective changes of this PR are minimal, with a change in hostname and that the daemon will now listen to IPv6 as well as IPv4

```
--hostname=tideways -> --hostname=tideways-daemon
--address=0.0.0.0:9135 -> --address=[::]:9135
```

#### Related resources

https://support.tideways.com/documentation/setup/installation/docker-with-compose.html#tideways-daemon-container

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
