### PR TITLE
Adds Mailpit mail-catcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ For contribution guidelines, see [Code contribution guide](https://docs.spryker.
 | webdriver       | phantomjs    | latest*       |             |                                    |
 |                 | chromedriver | latest        | &check;     |                                    |
 | mail_catcher    | mailhog      | 1.0           | &check;     |                                    |
+|                 | mailpit      | 1.22          | &check;     |                                    |
 | swagger         | swagger-ui   | v3.24         | &check;     |                                    |
 | kibana          | kibana       | 5.6*          | &check;     | https://www.elastic.co/support/eol |
 |                 |              | 6.8           | &check;     | https://www.elastic.co/support/eol |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ For contribution guidelines, see [Code contribution guide](https://docs.spryker.
 |                 | chromedriver | latest        | &check;     |                                    |
 | mail_catcher    | mailhog      | 1.0           | &check;     |                                    |
 |                 | mailpit      | 1.22          | &check;     |                                    |
+|                 |              | latest        | &check;     |                                    |
 | swagger         | swagger-ui   | v3.24         | &check;     |                                    |
 | kibana          | kibana       | 5.6*          | &check;     | https://www.elastic.co/support/eol |
 |                 |              | 6.8           | &check;     | https://www.elastic.co/support/eol |

--- a/ci/deploy.dev.yml
+++ b/ci/deploy.dev.yml
@@ -89,7 +89,7 @@ services:
     endpoints:
       scheduler.spryker.local:
   mail_catcher:
-    engine: mailhog
+    engine: mailpit
     endpoints:
       mail.spryker.local:
 

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -86,7 +86,7 @@ services:
     endpoints:
       scheduler.spryker.local:
   mail_catcher:
-    engine: mailhog
+    engine: mailpit
     endpoints:
       mail.spryker.local:
 

--- a/docs/06-configuring-services.md
+++ b/docs/06-configuring-services.md
@@ -11,6 +11,7 @@ This document describes configuration options of the services shipped with Spryk
 *     [Redis](#redis)
 *     [Redis GUI](#redis-gui)
 *     [MailHog](#mailhog)
+*     [Mailpit](#mailpit)
 *     [Blackfire](#blackfire)
 *     [New Relic](#new-relic)
 *     [WebDriver](#webdriver)
@@ -327,7 +328,7 @@ With the MailHog service, developers can:
 
 :::(Info) ()
 By default the following applies:
-*  `http://mail.demo-spryker.com/` is used to see incoming emails.
+*  `http://mail.spryker.local/` is used to see incoming emails.
 * Login is not required
 :::
 ### Configuration
@@ -338,6 +339,37 @@ services:
         ...
         mail_catcher:
                 engine: mailhog
+                endpoints:
+                          {custom_endpoint}:
+```
+2. Bootstrap the docker setup and rebuild the application:
+```bash
+docker/sdk boot deploy.*.yml &&\
+docker/sdk up
+```
+
+## Mailpit
+
+[Mailpit](https://github.com/axllent/mailpit) is a mail catcher service that is used with Spryker in Docker for Demo and Development environments. Developers use this email testing tool to catch and show emails locally without an SMTP (Simple Mail Transfer Protocol) server.
+
+With the Mailpit service, developers can:
+
+* configure an application to use Mailpit for SMTP delivery;
+* view messages in the web UI or retrieve them via JSON API.
+
+:::(Info) ()
+By default the following applies:
+*  `http://mail.spryker.local/` is used to see incoming emails.
+* Login is not required
+  :::
+### Configuration
+
+1. Adjust `deploy.*.yml` in the `services:` section to specify a custom endpoint:
+```yaml
+services:
+        ...
+        mail_catcher:
+                engine: mailpit
                 endpoints:
                           {custom_endpoint}:
 ```
@@ -528,7 +560,7 @@ docker/sdk up
 
 By default, in the New Relic dashboard, the APM is displayed as `company-staging-newrelic-app`. To improve visibility, you may want to configure each application as a separate APM. For example, `YVES-DE (docker.dev)`.
 
-To do it, adjust the Monitoring service in `src/Pyz/Service/Monitoring/MonitoringDependencyProvider.php`:  
+To do it, adjust the Monitoring service in `src/Pyz/Service/Monitoring/MonitoringDependencyProvider.php`:
 
 ```php
 <?php declare(strict_types = 1);

--- a/docs/07-deploy-file/02-deploy.file.reference.v1.md
+++ b/docs/07-deploy-file/02-deploy.file.reference.v1.md
@@ -584,7 +584,7 @@ services:
       scheduler.spryker.local:
 
   mail_catcher:
-    engine: mailhog
+    engine: mailpit
     endpoints:
       mail.spryker.local:
  ```
@@ -979,7 +979,7 @@ A mail catcher *Service* used to catch all outgoing emails for development or te
 
 * Project-wide
 
-     - `mail_catcher: engine:` - possible value is `mailhog`.
+     - `mail_catcher: engine:` - possible values are `mailpit` or `mailhog`.
      - `mail_catcher: endpoints:`- defines the service's port and web interface that can be accessed via given endpoints.
 
 

--- a/generator/deploy-file-generator/templates/environment/ci/services.deploy.template.yml
+++ b/generator/deploy-file-generator/templates/environment/ci/services.deploy.template.yml
@@ -15,4 +15,4 @@ services:
     scheduler:
         engine: jenkins
     mail_catcher:
-        engine: mailhog
+        engine: mailpit

--- a/generator/deploy-file-generator/templates/environment/demo/services.deploy.template.yml
+++ b/generator/deploy-file-generator/templates/environment/demo/services.deploy.template.yml
@@ -31,7 +31,7 @@ services:
         endpoints:
             scheduler.spryker.local:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.spryker.local:
     swagger:

--- a/generator/deploy-file-generator/templates/environment/dev/services.deploy.template.yml
+++ b/generator/deploy-file-generator/templates/environment/dev/services.deploy.template.yml
@@ -31,7 +31,7 @@ services:
         endpoints:
             scheduler.spryker.local:
     mail_catcher:
-        engine: mailhog
+        engine: mailpit
         endpoints:
             mail.spryker.local:
     swagger:

--- a/generator/src/templates/nginx/http/gateway/mailpit.server.conf.twig
+++ b/generator/src/templates/nginx/http/gateway/mailpit.server.conf.twig
@@ -1,0 +1,2 @@
+{% extends "nginx/http/gateway/server.conf.twig" %}
+{% block upstream %}{{ upstream }}:8025{% endblock upstream %}

--- a/generator/src/templates/service/mailpit/default/mailpit.yml.twig
+++ b/generator/src/templates/service/mailpit/default/mailpit.yml.twig
@@ -1,0 +1,1 @@
+{% include "service/#{engine}/latest/#{engine}.yml.twig" with _context only %}

--- a/generator/src/templates/service/mailpit/latest/mailpit.yml.twig
+++ b/generator/src/templates/service/mailpit/latest/mailpit.yml.twig
@@ -1,0 +1,19 @@
+  {{ serviceName }}:
+    image: axllent/mailpit
+    networks:
+        - private
+    labels:
+        'spryker.app.name': mailcatcher
+        'spryker.app.type': services
+        'spryker.project': ${SPRYKER_DOCKER_PREFIX}:${SPRYKER_DOCKER_TAG}
+    environment:
+        MP_SMTP_BIND_ADDR: 0.0.0.0:1025
+        MP_SMTP_AUTH_ACCEPT_ANY: 1
+        MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    healthcheck:
+        test: [ "CMD", "nc", "-z", "localhost", "1025" ]
+        interval: 5s
+        timeout: 5s
+        retries: 5
+    volumes:
+        - {{ serviceName }}-{{ serviceData['engine'] }}-data:/maildir

--- a/generator/src/templates/service/mailpit/v1.22/mailpit.yml.twig
+++ b/generator/src/templates/service/mailpit/v1.22/mailpit.yml.twig
@@ -1,0 +1,19 @@
+  {{ serviceName }}:
+    image: axllent/mailpit:v1.22
+    networks:
+        - private
+    labels:
+        'spryker.app.name': mailcatcher
+        'spryker.app.type': services
+        'spryker.project': ${SPRYKER_DOCKER_PREFIX}:${SPRYKER_DOCKER_TAG}
+    environment:
+        MP_SMTP_BIND_ADDR: 0.0.0.0:1025
+        MP_SMTP_AUTH_ACCEPT_ANY: 1
+        MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    healthcheck:
+        test: [ "CMD", "nc", "-z", "localhost", "1025" ]
+        interval: 5s
+        timeout: 5s
+        retries: 5
+    volumes:
+        - {{ serviceName }}-{{ serviceData['engine'] }}-data:/maildir


### PR DESCRIPTION
### Description

MailHog is dead (https://github.com/mailhog/MailHog/issues/442#issuecomment-1493415258), Mailpit is the active and maintained successor including features like viewing attachments in the preview of the emails.

#### Related resources

- https://github.com/mailhog/MailHog/issues/442#issuecomment-1493415258

#### Change log

- Introduces Mailpit as standard mail-catcher

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
