### PR TITLE
Introduced proxy_ssl_server_name directive

### DIFF
--- a/generator/src/templates/nginx/http/proxy/reverse-proxy.conf.twig
+++ b/generator/src/templates/nginx/http/proxy/reverse-proxy.conf.twig
@@ -5,6 +5,7 @@ location {{ location }} {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $http_host;
+        proxy_ssl_server_name on;
 
         proxy_pass {{ proxy_pass }};
     }


### PR DESCRIPTION
### Description

- Ticket/Issue: SF-64390

Enables passing of the server name through [TLS Server Name Indication extension](http://en.wikipedia.org/wiki/Server_Name_Indication) (SNI, RFC 6066) when establishing a connection with the proxied HTTPS server.

#### Change log

Added proxy_ssl_server_name directive.

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
