### PR TITLE
feat: Enhance Nginx log_format

### DIFF
--- a/context/nginx/nginx.original.conf
+++ b/context/nginx/nginx.original.conf
@@ -19,8 +19,10 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    log_format sprykerextended '$status $host $remote_addr - $remote_user [$time_local] "$request" "$http_referer" '
-                               '"$http_user_agent" $body_bytes_sent $request_time $scheme/$ssl_protocol/$ssl_cipher '
+    log_format sprykerextended '$remote_addr - $remote_user [$time_local] '
+                               '"$request" $status $body_bytes_sent '
+                               '"$http_referer" "$http_user_agent" '
+                               '$host $request_time $scheme/$ssl_protocol/$ssl_cipher '
                                '$upstream_response_time $upstream_addr';
 
     access_log  /var/log/nginx/access.log  sprykerextended;

--- a/context/nginx/nginx.original.conf
+++ b/context/nginx/nginx.original.conf
@@ -19,7 +19,11 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    log_format sprykerextended '$status $host $remote_addr - $remote_user [$time_local] "$request" "$http_referer" '
+                               '"$http_user_agent" $body_bytes_sent $request_time $scheme/$ssl_protocol/$ssl_cipher '
+                               '$upstream_response_time $upstream_addr';
+
+    access_log  /var/log/nginx/access.log  sprykerextended;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/context/nginx/nginx.with.stream.conf
+++ b/context/nginx/nginx.with.stream.conf
@@ -19,8 +19,10 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    log_format sprykerextended '$status $host $remote_addr - $remote_user [$time_local] "$request" "$http_referer" '
-                               '"$http_user_agent" $body_bytes_sent $request_time $scheme/$ssl_protocol/$ssl_cipher '
+    log_format sprykerextended '$remote_addr - $remote_user [$time_local] '
+                               '"$request" $status $body_bytes_sent '
+                               '"$http_referer" "$http_user_agent" '
+                               '$host $request_time $scheme/$ssl_protocol/$ssl_cipher '
                                '$upstream_response_time $upstream_addr';
 
     access_log  /var/log/nginx/access.log  sprykerextended;

--- a/context/nginx/nginx.with.stream.conf
+++ b/context/nginx/nginx.with.stream.conf
@@ -19,7 +19,12 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    log_format sprykerextended '$status $host $remote_addr - $remote_user [$time_local] "$request" "$http_referer" '
+                               '"$http_user_agent" $body_bytes_sent $request_time $scheme/$ssl_protocol/$ssl_cipher '
+                               '$upstream_response_time $upstream_addr';
+
+    access_log  /var/log/nginx/access.log  sprykerextended;
+
 
     sendfile        on;
     #tcp_nopush     on;

--- a/generator/src/templates/nginx/http/server.conf.twig
+++ b/generator/src/templates/nginx/http/server.conf.twig
@@ -27,7 +27,7 @@ server {
 
 {% endif %}
 {% endblock auth %}
-    access_log /dev/stdout combined;
+    access_log /dev/stdout sprykerextended;
     error_log /dev/stderr;
 
 {% block locations %}


### PR DESCRIPTION
### Description

Previous log_format example: 

```
11.11.11.11 - - [06/Apr/2025:21:28:41 +0000] "GET /store/switch?store=OST&referer-url=/cs/search?q=kick+buttowski HTTP/1.1" 302 366 "-" "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/116.0.1938.76 Safari/537.36" 
``` 
New log_format example: 

```
11.11.11.11 - - [08/Apr/2025:08:21:16 +0000] "GET /cs/search?q=outdoor%20kitchen&page=1 HTTP/1.1" 200 165243 "-" "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/116.0.1938.76 Safari/537.36" shop.my.shop 1.378 http/-/- 1.380 10.106.6.107:1234
``` 

The latter one improves the debugging experience. New fields are appended to the end of the list ensuring backward-compatibility.

#### Related resources

<!-- Reference all related PRs or other resources -->

- <!-- URL_HERE -->

#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- <!-- Please, add all changes one by one. E.g "Adjusted something", "Removed something"... -->

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
