### PR TITLE
fix docker/sdk config deploy.dev.yml

### DIFF
--- a/generator/deploy-file-generator/Dockerfile
+++ b/generator/deploy-file-generator/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-ARG SPRYKER_PHP_IMAGE
+ARG SPRYKER_PHP_IMAGE=spryker/php:8.2
 
 FROM ${SPRYKER_PHP_IMAGE}
 


### PR DESCRIPTION
Fixed an issue where docker/sdk config won´t work with viewing  deploy files full config.

### Description

- Ticket/Issue: n/A

<!-- Please, write background  -->

#### Related resources

docker/sdk config deploy.dev.yml won't work due to missing argument for spryker php image

#### Change log

n/A

### Checklist
- [x ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
