### PR TITLE
Add v3_ca extension to CA cert generation

### DIFF
--- a/generator/openssl/generate.sh
+++ b/generator/openssl/generate.sh
@@ -11,8 +11,21 @@ then
     cp "${SOURCE}/default.crt" "${DESTINATION}/ca.crt"
 else
     echo -e "Generating CA cert and private key"
-    openssl req -nodes -newkey rsa:2048 -out "${DESTINATION}/ca.csr" -keyout "${DESTINATION}/ca.key" -subj "/C=DE/ST=Berlin/L=Berlin/O=Spryker/CN=Spryker"
-    openssl x509 -req -days 9999 -in "${DESTINATION}/ca.csr" -signkey "${DESTINATION}/ca.key" -out "${DESTINATION}/ca.crt"
+    openssl req \
+        -nodes \
+        -newkey rsa:2048 \
+        -out "${DESTINATION}/ca.csr" \
+        -keyout "${DESTINATION}/ca.key" \
+        -subj "/C=DE/ST=Berlin/L=Berlin/O=Spryker/CN=Spryker"
+
+    openssl x509 \
+        -req \
+        -days 9999 \
+        -in "${DESTINATION}/ca.csr" \
+        -signkey "${DESTINATION}/ca.key" \
+        -out "${DESTINATION}/ca.crt" \
+        -extensions v3_ca \
+        -extfile "${SOURCE}/v3_ca.ext"
 fi
 
 echo -e "Generating PFX file for CA to import on client side"

--- a/generator/openssl/v3_ca.ext
+++ b/generator/openssl/v3_ca.ext
@@ -1,0 +1,5 @@
+[ v3_ca ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical,CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign


### PR DESCRIPTION
### Description

If you using PHP8.2 in the docker/sdk [generator Dockerfile](https://github.com/spryker/docker-sdk/blob/master/generator/Dockerfile#L2) and enable ssl generation in spryker you are not able to generate a valid ssl certificate because the CA certificate is missing the CA flag.

As PHP8.0 is still used by default, but is not supported anymore, upgrading to PHP8.2 should be recommended, but not possible at the moment, due to this SSL error.

Example deploy.dev.yml
```yaml
docker:
    ssl:
        enabled: true
        redirect: true
```

Error message with PHP8.2:
```bash
Certificate request self-signature ok
subject=C=DE, ST=Berlin, L=Berlin, OU=Spryker, O=Spryker, CN=Spryker
C=DE, ST=Berlin, L=Berlin, O=Spryker, CN=Spryker
error 79 at 1 depth lookup: invalid CA certificate
error /data/deployment/context/nginx/ssl/ssl.crt: verification failed
```

These changes works without any problems with `spryker/php` version `8.0`, `8.1`, `8.2` and `8.3`.

OpenSSL Versions:
| `spryker/php` | OpenSSL version |
|---|---|
| 8.0 | `OpenSSL 1.1.1w  11 Sep 2023` |
| 8.1 | `OpenSSL 3.3.2 3 Sep 2024 (Library: OpenSSL 3.3.2 3 Sep 2024)` |
| 8.2 | `OpenSSL 3.3.2 3 Sep 2024 (Library: OpenSSL 3.3.2 3 Sep 2024)` |
| 8.3 | `OpenSSL 3.3.4 1 Jul 2025 (Library: OpenSSL 3.3.4 1 Jul 2025)` |


#### Change log

<!-- Relevant changes. Those will be copied into the release log. -->

- <!-- Please, add all changes one by one. E.g "Adjusted something", "Removed something"... --> Adjusted SSL CA generation to be compatible with OpenSSL ^3.0 

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
