### PR TITLE
Bump default RMQ version

### DIFF
--- a/generator/src/templates/service/rabbitmq/default/rabbitmq.yml.twig
+++ b/generator/src/templates/service/rabbitmq/default/rabbitmq.yml.twig
@@ -1,1 +1,1 @@
-{% include "service/#{engine}/3.7/#{engine}.yml.twig" with _context only %}
+{% include "service/#{engine}/3.13/#{engine}.yml.twig" with _context only %}


### PR DESCRIPTION
### Description

If RMQ version isn't specifically defined in the deploy file, old 3.7.14 will be used which is not a desired behavior.

#### Change log

Bump default RMQ version to 3.13

### Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
