### PR TITLE
CC-36444: Use composer cache from host filesystem (speeds baked builds)

### DIFF
--- a/bin/sdk/images/common.sh
+++ b/bin/sdk/images/common.sh
@@ -45,6 +45,10 @@ function Images::_buildApp() {
         sshArgument=('--ssh' 'default')
     fi
 
+    # Pre-populate Docker BuildKit composer cache from host
+    Console::verbose "${INFO}Pre-populating composer cache...${NC}"
+    bash "${BASH_SOURCE%/*}/prepopulate-composer-cache.sh" || Console::verbose "${WARN}Cache pre-population skipped${NC}"
+
     Images::_prepareSecrets
     Registry::Trap::addExitHook 'removeBuildSecrets' "rm -f ${SECRETS_FILE_PATH}"
 

--- a/bin/sdk/images/common.sh
+++ b/bin/sdk/images/common.sh
@@ -47,7 +47,7 @@ function Images::_buildApp() {
 
     # Pre-populate Docker BuildKit composer cache from host
     Console::verbose "${INFO}Pre-populating composer cache...${NC}"
-    bash "${BASH_SOURCE%/*}/prepopulate-composer-cache.sh" || Console::verbose "${WARN}Cache pre-population skipped${NC}"
+    bash "${BASH_SOURCE%/*}/prepopulate-composer-cache.sh"
 
     Images::_prepareSecrets
     Registry::Trap::addExitHook 'removeBuildSecrets' "rm -f ${SECRETS_FILE_PATH}"

--- a/bin/sdk/images/common.sh
+++ b/bin/sdk/images/common.sh
@@ -46,8 +46,10 @@ function Images::_buildApp() {
     fi
 
     # Pre-populate Docker BuildKit composer cache from host
-    Console::verbose "${INFO}Pre-populating composer cache...${NC}"
-    bash "${BASH_SOURCE%/*}/prepopulate-composer-cache.sh"
+    if [ "${folder}" == "baked" ]; then
+        Console::verbose "${INFO}Pre-populating composer cache...${NC}"
+        bash "${BASH_SOURCE%/*}/prepopulate-composer-cache.sh"
+    fi
 
     Images::_prepareSecrets
     Registry::Trap::addExitHook 'removeBuildSecrets' "rm -f ${SECRETS_FILE_PATH}"

--- a/bin/sdk/images/prepopulate-composer-cache.sh
+++ b/bin/sdk/images/prepopulate-composer-cache.sh
@@ -30,15 +30,18 @@ mkdir -p "${TEMP_CONTEXT}/cache"
 cp -a "${COMPOSER_CACHE_DIR}/." "${TEMP_CONTEXT}/cache/" 2>/dev/null || true
 
 # Create a temporary Dockerfile to copy cache into Docker's cache mount
+# Using the same cache id and target path as the main Dockerfile
 cat > "${TEMP_CONTEXT}/Dockerfile" <<'EOF'
 FROM alpine:latest
-COPY cache /cache-source
-RUN --mount=type=cache,id=composer,sharing=locked,target=/cache \
+RUN adduser -u 1000 -D spryker
+USER spryker
+COPY --chown=spryker:spryker cache /cache-source
+RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \
     if [ -n "$(ls -A /cache-source 2>/dev/null)" ]; then \
         echo "Copying composer cache to Docker cache mount..."; \
-        cp -a /cache-source/. /cache/ 2>/dev/null || true; \
+        cp -a /cache-source/. /home/spryker/.composer/cache/ 2>/dev/null || true; \
         echo "Cache pre-population complete. Cache directory size:"; \
-        du -sh /cache 2>/dev/null || echo "Cache populated"; \
+        du -sh /home/spryker/.composer/cache 2>/dev/null || echo "Cache populated"; \
     else \
         echo "No files to copy from source cache"; \
     fi

--- a/bin/sdk/images/prepopulate-composer-cache.sh
+++ b/bin/sdk/images/prepopulate-composer-cache.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Pre-populate Docker BuildKit composer cache from host composer cache
+# This speeds up Docker builds by copying existing composer packages into Docker's cache mount
+
+set -e
+
+COMPOSER_CACHE_DIR=$(composer config cache-dir)
+
+echo "Pre-populating Docker BuildKit cache from ${COMPOSER_CACHE_DIR}"
+
+if [ ! -d "${COMPOSER_CACHE_DIR}" ]; then
+    echo "Warning: Composer cache directory ${COMPOSER_CACHE_DIR} does not exist. Skipping pre-population."
+    exit 0
+fi
+
+# Create a temporary Dockerfile to copy cache into Docker's cache mount
+cat > /tmp/prepopulate-cache.Dockerfile <<'EOF'
+FROM alpine:latest
+ARG COMPOSER_CACHE_DIR
+RUN --mount=type=cache,id=composer,sharing=locked,target=/cache \
+    if [ -n "$(ls -A /source 2>/dev/null)" ]; then \
+        echo "Copying composer cache to Docker cache mount..."; \
+        cp -a /source/. /cache/ || true; \
+        echo "Cache pre-population complete. Files in cache:"; \
+        ls -lah /cache | head -20; \
+    else \
+        echo "No files to copy from source cache"; \
+    fi
+EOF
+
+# Build the temporary image to populate the cache
+DOCKER_BUILDKIT=1 docker build \
+    --build-arg COMPOSER_CACHE_DIR="${COMPOSER_CACHE_DIR}" \
+    --mount type=bind,source="${COMPOSER_CACHE_DIR}",target=/source \
+    -f /tmp/prepopulate-cache.Dockerfile \
+    /tmp
+
+rm -f /tmp/prepopulate-cache.Dockerfile
+
+echo "Docker BuildKit composer cache pre-populated successfully!"
+

--- a/bin/sdk/images/prepopulate-composer-cache.sh
+++ b/bin/sdk/images/prepopulate-composer-cache.sh
@@ -13,12 +13,12 @@ fi
 
 COMPOSER_CACHE_DIR=$(composer config cache-dir)
 
-echo "Pre-populating Docker BuildKit cache from ${COMPOSER_CACHE_DIR}"
-
-if [ ! -d "${COMPOSER_CACHE_DIR}" ]; then
-    echo "Warning: Composer cache directory ${COMPOSER_CACHE_DIR} does not exist. Skipping pre-population."
+if [ -z "$(ls -A "${COMPOSER_CACHE_DIR}" 2>/dev/null | grep -v '^\.htaccess$')" ]; then
+    echo "Warning: Composer cache directory ${COMPOSER_CACHE_DIR} is empty (excluding .htaccess). Skipping pre-population."
     exit 0
 fi
+
+echo "Pre-populating Docker BuildKit cache from ${COMPOSER_CACHE_DIR}"
 
 # Create a temporary directory for the build context
 TEMP_CONTEXT=$(mktemp -d)

--- a/bin/sdk/images/prepopulate-composer-cache.sh
+++ b/bin/sdk/images/prepopulate-composer-cache.sh
@@ -5,6 +5,12 @@
 
 set -e
 
+# Check if composer is installed
+if ! command -v composer &> /dev/null; then
+    echo "Warning: composer command not found. Skipping cache pre-population."
+    exit 0
+fi
+
 COMPOSER_CACHE_DIR=$(composer config cache-dir)
 
 echo "Pre-populating Docker BuildKit cache from ${COMPOSER_CACHE_DIR}"
@@ -14,16 +20,25 @@ if [ ! -d "${COMPOSER_CACHE_DIR}" ]; then
     exit 0
 fi
 
+# Create a temporary directory for the build context
+TEMP_CONTEXT=$(mktemp -d)
+trap "rm -rf ${TEMP_CONTEXT}" EXIT
+
+# Copy composer cache to temporary context
+echo "Copying cache to temporary context..."
+mkdir -p "${TEMP_CONTEXT}/cache"
+cp -a "${COMPOSER_CACHE_DIR}/." "${TEMP_CONTEXT}/cache/" 2>/dev/null || true
+
 # Create a temporary Dockerfile to copy cache into Docker's cache mount
-cat > /tmp/prepopulate-cache.Dockerfile <<'EOF'
+cat > "${TEMP_CONTEXT}/Dockerfile" <<'EOF'
 FROM alpine:latest
-ARG COMPOSER_CACHE_DIR
+COPY cache /cache-source
 RUN --mount=type=cache,id=composer,sharing=locked,target=/cache \
-    if [ -n "$(ls -A /source 2>/dev/null)" ]; then \
+    if [ -n "$(ls -A /cache-source 2>/dev/null)" ]; then \
         echo "Copying composer cache to Docker cache mount..."; \
-        cp -a /source/. /cache/ || true; \
-        echo "Cache pre-population complete. Files in cache:"; \
-        ls -lah /cache | head -20; \
+        cp -a /cache-source/. /cache/ 2>/dev/null || true; \
+        echo "Cache pre-population complete. Cache directory size:"; \
+        du -sh /cache 2>/dev/null || echo "Cache populated"; \
     else \
         echo "No files to copy from source cache"; \
     fi
@@ -31,12 +46,7 @@ EOF
 
 # Build the temporary image to populate the cache
 DOCKER_BUILDKIT=1 docker build \
-    --build-arg COMPOSER_CACHE_DIR="${COMPOSER_CACHE_DIR}" \
-    --mount type=bind,source="${COMPOSER_CACHE_DIR}",target=/source \
-    -f /tmp/prepopulate-cache.Dockerfile \
-    /tmp
-
-rm -f /tmp/prepopulate-cache.Dockerfile
+    -f "${TEMP_CONTEXT}/Dockerfile" \
+    "${TEMP_CONTEXT}"
 
 echo "Docker BuildKit composer cache pre-populated successfully!"
-

--- a/images/baked/application/Dockerfile
+++ b/images/baked/application/Dockerfile
@@ -5,14 +5,19 @@ FROM ${SPRYKER_PARENT_IMAGE} AS application-production-dependencies
 
 USER spryker
 
-# Install composer modules for Spryker
 COPY --chown=spryker:spryker composer.json composer.lock ${srcRoot}/
-ARG SPRYKER_COMPOSER_MODE
-ARG SPRYKER_COMPOSER_VERBOSE
-RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \
-  --mount=type=ssh,uid=1000 --mount=type=secret,id=secrets-env,uid=1000 \
-  set -o allexport && . /run/secrets/secrets-env && set +o allexport \
-  && composer install --no-scripts --no-interaction ${SPRYKER_COMPOSER_MODE} ${SPRYKER_COMPOSER_VERBOSE}
+COPY --chown=spryker:spryker vendor ${srcRoot}/vendor
+
+# Install composer modules for Spryker only if vendor is missing
+#ARG SPRYKER_COMPOSER_MODE
+#ARG SPRYKER_COMPOSER_VERBOSE
+#RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \
+#    --mount=type=ssh,uid=1000 \
+#    --mount=type=secret,id=secrets-env,uid=1000 \
+#    bash -c 'if [ ! -d "${srcRoot}/vendor" ] || [ -z "$(ls -A ${srcRoot}/vendor)" ]; then \
+#      set -o allexport && . /run/secrets/secrets-env && set +o allexport \
+#      && composer install --no-scripts --no-interaction ${SPRYKER_COMPOSER_MODE} ${SPRYKER_COMPOSER_VERBOSE}; \
+#    fi'
 
 FROM application-production-dependencies AS application-production-codebase
 

--- a/images/baked/application/Dockerfile
+++ b/images/baked/application/Dockerfile
@@ -5,19 +5,16 @@ FROM ${SPRYKER_PARENT_IMAGE} AS application-production-dependencies
 
 USER spryker
 
+# Install composer modules for Spryker
 COPY --chown=spryker:spryker composer.json composer.lock ${srcRoot}/
-COPY --chown=spryker:spryker vendor ${srcRoot}/vendor
 
-# Install composer modules for Spryker only if vendor is missing
-#ARG SPRYKER_COMPOSER_MODE
-#ARG SPRYKER_COMPOSER_VERBOSE
-#RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \
-#    --mount=type=ssh,uid=1000 \
-#    --mount=type=secret,id=secrets-env,uid=1000 \
-#    bash -c 'if [ ! -d "${srcRoot}/vendor" ] || [ -z "$(ls -A ${srcRoot}/vendor)" ]; then \
-#      set -o allexport && . /run/secrets/secrets-env && set +o allexport \
-#      && composer install --no-scripts --no-interaction ${SPRYKER_COMPOSER_MODE} ${SPRYKER_COMPOSER_VERBOSE}; \
-#    fi'
+ARG SPRYKER_COMPOSER_MODE
+ARG SPRYKER_COMPOSER_VERBOSE
+RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \
+    --mount=type=ssh,uid=1000 \
+    --mount=type=secret,id=secrets-env,uid=1000 \
+    set -o allexport && . /run/secrets/secrets-env && set +o allexport \
+    && composer install --no-scripts --no-interaction ${SPRYKER_COMPOSER_MODE} ${SPRYKER_COMPOSER_VERBOSE}
 
 FROM application-production-dependencies AS application-production-codebase
 

--- a/images/baked/cli/Dockerfile
+++ b/images/baked/cli/Dockerfile
@@ -7,11 +7,12 @@ USER spryker
 
 # Install composer modules for Spryker
 COPY --chown=spryker:spryker composer.json composer.lock ${srcRoot}/
-ARG SPRYKER_COMPOSER_MODE
-RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \
-  --mount=type=ssh,uid=1000 --mount=type=secret,id=secrets-env,uid=1000 \
-  set -o allexport && . /run/secrets/secrets-env && set +o allexport \
-  && composer install --no-interaction ${SPRYKER_COMPOSER_MODE}
+
+#ARG SPRYKER_COMPOSER_MODE
+#RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \
+#  --mount=type=ssh,uid=1000 --mount=type=secret,id=secrets-env,uid=1000 \
+#  set -o allexport && . /run/secrets/secrets-env && set +o allexport \
+#  && composer install --no-interaction ${SPRYKER_COMPOSER_MODE}
 
 ARG SPRYKER_COMPOSER_AUTOLOAD
 RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \

--- a/images/baked/cli/Dockerfile
+++ b/images/baked/cli/Dockerfile
@@ -7,12 +7,12 @@ USER spryker
 
 # Install composer modules for Spryker
 COPY --chown=spryker:spryker composer.json composer.lock ${srcRoot}/
-
-#ARG SPRYKER_COMPOSER_MODE
-#RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \
-#  --mount=type=ssh,uid=1000 --mount=type=secret,id=secrets-env,uid=1000 \
-#  set -o allexport && . /run/secrets/secrets-env && set +o allexport \
-#  && composer install --no-interaction ${SPRYKER_COMPOSER_MODE}
+ARG SPRYKER_COMPOSER_MODE
+RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \
+    --mount=type=ssh,uid=1000 \
+    --mount=type=secret,id=secrets-env,uid=1000 \
+    set -o allexport && . /run/secrets/secrets-env && set +o allexport \
+    && composer install --no-interaction ${SPRYKER_COMPOSER_MODE}
 
 ARG SPRYKER_COMPOSER_AUTOLOAD
 RUN --mount=type=cache,id=composer,sharing=locked,target=/home/spryker/.composer/cache,uid=1000 \


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/CC-36444

In CI jobs with builds using baked filesystem we cannot reuse cached folders for composer, which is ~900MB. And the build process downloads all packages every time.

#### Related resources

<img width="1071" height="1273" alt="image" src="https://github.com/user-attachments/assets/e3c007de-9d37-4500-b8cc-4e2e0619ecfe" />

CI log with baked `docker/sdk up` https://github.com/spryker/suite-nonsplit/actions/runs/18718201883/job/53383776766#logs

#### Change log

- Added script that is executed only in "baked" mode, which pre-populates Docker cache with `id=composer` by building a temporary image.

### Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
