### PR TITLE
Fix Yarn install on Debian to avoid expiring GPG key (#603)

### DIFF
--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -28,14 +28,16 @@ RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
      make \
      ; fi'
 
-# Debian contains outdated Yarn package
-RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
-    --mount=type=cache,id=aptcache,sharing=locked,target=/var/cache/apt \
-  bash -c 'if [ ! -z "$(which apt)" ]; then \
-     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-     apt update -y && apt install -y \
-     yarn \
+# Yarn installed via Node.js + npm. Replaces the deprecated apt-key path and
+# the dl.yarnpkg.com repo whose GPG key periodically expires (issue #603).
+ARG NODE_VERSION=20.18.1
+ARG YARN_VERSION=1.22.22
+RUN bash -c 'if [ ! -z "$(which apt)" ]; then \
+     architecture=$(case $(uname -m) in x86_64|amd64) echo "x64" ;; aarch64|arm64) echo "arm64" ;; *) echo "x64" ;; esac) && \
+     curl -fsSLO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${architecture}.tar.gz" && \
+     tar -xzf "node-v${NODE_VERSION}-linux-${architecture}.tar.gz" -C /usr/local --strip-components=1 --no-same-owner && \
+     rm "node-v${NODE_VERSION}-linux-${architecture}.tar.gz" && \
+     npm install --global --no-fund --no-audit "yarn@${YARN_VERSION}" \
      ; fi'
 
 RUN --mount=type=cache,id=apk,sharing=locked,target=/var/cache/apk mkdir -p /etc/apk && ln -vsf /var/cache/apk /etc/apk/cache && \


### PR DESCRIPTION
## Summary
- Replaces the deprecated `apt-key add` path and the third-party `dl.yarnpkg.com/debian` repo with a pinned Node.js binary install + `npm install -g yarn@<pinned>`.
- Fixes [#603](https://github.com/spryker/docker-sdk/issues/603): builds broke on 2026-01-23 with `EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>` when Yarn's signing key expired, and `apt-key` itself is deprecated since Debian 11.
- Only the Debian branch is changed. The Alpine branch (`apk add yarn`) is untouched — it's not affected by either issue.

## Why `npm install -g` and not Corepack
Corepack is the path Yarn's docs recommend, but it stores its package cache under `$COREPACK_HOME` and extends that cache lazily on first use. The Spryker CLI image switches to a non-root `spryker` user later in the Dockerfile, and that user can't write to a root-owned `COREPACK_HOME`, so the first `yarn add` invocation under `spryker` fails with `Failed to create cache directory`. `npm install -g` writes Yarn permanently to `/usr/local/lib/node_modules/yarn` at build time and needs no writable runtime cache, so it works cleanly across the user switch.

## Notes
- Image grows by the Node runtime (~75 MB extracted). `NODE_VERSION` and `YARN_VERSION` are exposed as `ARG`s for build-time override.
- HTTPS-only download from `nodejs.org/dist`; consistent with how the SDK already installs Blackfire / NewRelic / Tideways / GraphViz. A stricter follow-up could verify SHASUMS256.txt + the Node release GPG signature.

## Test plan
- [x] Verified end-to-end on `debian:bullseye-slim`: `yarn --version` returns `1.22.22` for both root and a non-root user; `yarn init` and `yarn add lodash@4.17.21` produce a populated `node_modules`.
- [ ] Run the SDK CI build matrix to confirm both Debian and Alpine CLI images still build.
- [ ] Smoke-test `docker/sdk up` on a Spryker shop project that runs frontend asset builds (Yarn classic), to confirm `yarn install` and `yarn build` still succeed inside the CLI container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)