### PR TITLE
SC-25015: Yarn fix

### DIFF
--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -23,15 +23,13 @@ RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
      jq \
      ; fi'
 
-# Debian contains outdated Yarn package
-RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
-    --mount=type=cache,id=aptcache,sharing=locked,target=/var/cache/apt \
-  bash -c 'if [ ! -z "$(which apt)" ]; then \
-     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-     apt update -y && apt install -y \
-     yarn \
-     ; fi'
+# Debian contains outdated Yarn package, so Yarn 1.x (classic) is installed via npm.
+# The parent image copies /usr/local/bin from the node image, which includes yarn
+# symlinks pointing to the never-copied /opt/yarn-* directory; the dangling links
+# must be removed first or npm refuses to create its own.
+RUN bash -c 'if [ ! -z "$(which apt)" ]; then \
+     rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && \
+     npm install -g "yarn@1"; fi'
 
 RUN --mount=type=cache,id=apk,sharing=locked,target=/var/cache/apk mkdir -p /etc/apk && ln -vsf /var/cache/apk /etc/apk/cache && \
   bash -c 'if [ ! -z "$(which apk)" ]; then apk update && apk add \

--- a/images/common/cli/Dockerfile
+++ b/images/common/cli/Dockerfile
@@ -23,10 +23,7 @@ RUN --mount=type=cache,id=aptlib,sharing=locked,target=/var/lib/apt \
      jq \
      ; fi'
 
-# Debian contains outdated Yarn package, so Yarn 1.x (classic) is installed via npm.
-# The parent image copies /usr/local/bin from the node image, which includes yarn
-# symlinks pointing to the never-copied /opt/yarn-* directory; the dangling links
-# must be removed first or npm refuses to create its own.
+# Debian contains outdated Yarn package
 RUN bash -c 'if [ ! -z "$(which apt)" ]; then \
      rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && \
      npm install -g "yarn@1"; fi'


### PR DESCRIPTION
### Description

- Ticket/Issue: https://spryker.atlassian.net/browse/SC-25015
- ISSUE: https://github.com/spryker/docker-sdk/issues/603

#### Change log

- Replaced the deprecated apt-key based Yarn installation in the CLI image with an npm-based install to prevent build failures caused by expired Yarn repository GPG keys

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
