### PR TITLE
SF-OCTRIBE-887 (a) Fix merchant portal build error due to Node memory

### DIFF
--- a/generator/src/templates/env/cli/region.env.twig
+++ b/generator/src/templates/env/cli/region.env.twig
@@ -38,3 +38,5 @@ SPRYKER_BE_PORT={{ (regionEndpointMap['backoffice'] | split(':'))[1] | default(p
 {% if project['docker']['ssl']['enabled'] %}
 SPRYKER_SSL_ENABLE=1
 {% endif %}
+
+NODE_OPTIONS="--max-old-space-size=4096"

--- a/generator/src/templates/env/cli/store.env.twig
+++ b/generator/src/templates/env/cli/store.env.twig
@@ -43,3 +43,5 @@ SPRYKER_BE_PORT={{ (endpointMap[identifier]['backoffice'] | split(':'))[1] | def
 {% if project['docker']['ssl']['enabled'] %}
 SPRYKER_SSL_ENABLE=1
 {% endif %}
+
+NODE_OPTIONS="--max-old-space-size=4096"


### PR DESCRIPTION
### Description

Increase node heap memory limit.

All team members were getting a fatal error while trying to boostrap the related spryker-upgrade branch.

Error: Ineffective mark-compacts near heap limit... Allocation failed - JavaScript heap out of memory... 

### Checklist
- [x ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
