### PR TITLE
SF-OCTRIBE-887 (b) Issue with frontend login (oauth client secret)

### DIFF
--- a/generator/index.php
+++ b/generator/index.php
@@ -1411,7 +1411,7 @@ function buildSecrets(string $deploymentDir): array
     $data['SPRYKER_OAUTH_CLIENT_SECRET'] = generateToken(48);
     $data['SPRYKER_OAUTH_CLIENT_CONFIGURATION'] = json_encode([[
         "identifier" => "frontend",
-        "secret" => generateToken(48),
+        "secret" => $data['SPRYKER_OAUTH_CLIENT_SECRET'],
         "isConfidential" => true,
         "name" => "Customer client",
         "redirectUri" => null,


### PR DESCRIPTION
### Description

- Glue endpoint `/access-tokens` stopped working in our spryker-upgrade branch.
- Credits to our colleague Adrian for the resolution.

### Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
