### PR TITLE
CC-39933: revalidate static assets in development mode

### DIFF
--- a/generator/src/templates/nginx/http/static.conf.twig
+++ b/generator/src/templates/nginx/http/static.conf.twig
@@ -2,9 +2,17 @@
         auth_basic  off;
         allow       all;
         access_log  off;
+{% if assets['mode'] | default('') == 'development' %}
+{# Local development: assets are rebuilt in place under a constant build hash, so a
+   long freshness lifetime makes the browser serve stale CSS/JS from its own cache
+   without ever revalidating. Force revalidation so a normal reload picks up a
+   rebuild; the ETag below still yields 304s, so this stays cheap. #}
+        expires     -1;
+{% else %}
         expires     7d;
         add_header  Pragma public;
         add_header  Cache-Control "public, must-revalidate, proxy-revalidate";
+{% endif %}
         add_header  Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
         etag on;
         try_files   $uri @assets;
@@ -30,9 +38,14 @@
 
     location / {
         access_log  off;
+{% if assets['mode'] | default('') == 'development' %}
+{# See the note in /assets/ above: revalidate instead of caching for a week locally. #}
+        expires     -1;
+{% else %}
         expires     7d;
         add_header  Pragma public;
         add_header  Cache-Control "public, must-revalidate, proxy-revalidate";
+{% endif %}
         etag on;
         try_files   $uri @proxy;
     }

--- a/generator/src/templates/nginx/http/static.conf.twig
+++ b/generator/src/templates/nginx/http/static.conf.twig
@@ -3,10 +3,6 @@
         allow       all;
         access_log  off;
 {% if assets['mode'] | default('') == 'development' %}
-{# Local development: assets are rebuilt in place under a constant build hash, so a
-   long freshness lifetime makes the browser serve stale CSS/JS from its own cache
-   without ever revalidating. Force revalidation so a normal reload picks up a
-   rebuild; the ETag below still yields 304s, so this stays cheap. #}
         expires     -1;
 {% else %}
         expires     7d;
@@ -39,7 +35,6 @@
     location / {
         access_log  off;
 {% if assets['mode'] | default('') == 'development' %}
-{# See the note in /assets/ above: revalidate instead of caching for a week locally. #}
         expires     -1;
 {% else %}
         expires     7d;

--- a/generator/src/templates/nginx/http/static.server.conf.twig
+++ b/generator/src/templates/nginx/http/static.server.conf.twig
@@ -8,9 +8,15 @@
     location / {
         index index.html;
         access_log  off;
+{% if assets['mode'] | default('') == 'development' %}
+{# Local development: revalidate rather than trusting a week-long lifetime, so a
+   rebuilt asset is picked up by a normal reload instead of a hard one. #}
+        expires     -1;
+{% else %}
         expires     7d;
         add_header  Pragma public;
         add_header  Cache-Control "public, must-revalidate, proxy-revalidate";
+{% endif %}
         etag on;
         try_files   $uri $uri/ =404;
     }

--- a/generator/src/templates/nginx/http/static.server.conf.twig
+++ b/generator/src/templates/nginx/http/static.server.conf.twig
@@ -9,8 +9,6 @@
         index index.html;
         access_log  off;
 {% if assets['mode'] | default('') == 'development' %}
-{# Local development: revalidate rather than trusting a week-long lifetime, so a
-   rebuilt asset is picked up by a normal reload instead of a hard one. #}
         expires     -1;
 {% else %}
         expires     7d;


### PR DESCRIPTION
https://spryker.atlassian.net/browse/CC-39933

## Problem

Locally, rebuilt Yves / Back Office / Merchant Portal CSS and JS only show up after a browser **hard reload**.

Assets are served from a constant path — `SPRYKER_BUILD_HASH` defaults to `current` in development — while nginx sends:

```
expires     7d;
Cache-Control: public, must-revalidate, proxy-revalidate
```

Because the URL is identical after a rebuild *and* the response is still within its 7-day freshness lifetime, the browser satisfies the request from its own cache **without issuing a request at all**. The `etag on` / 304 handling already configured in this block is therefore never consulted. Only a hard reload, which bypasses freshness, picks up the rebuilt file.

Note `must-revalidate` does not help here: per RFC 9111 it only governs what a cache may do once a response is **stale**, so it has no effect during the 7 days the response is still fresh.

## Fix

When `assets.mode` is `development`, send `expires -1` (`Cache-Control: no-cache`) instead, so the browser revalidates on a normal reload.

Revalidation stays cheap — unchanged assets still return `304 Not Modified` through the existing ETag, so this trades a conditional request for correctness, not bandwidth.

## Scope of the guard

`assets['mode']` is only defined in the nginx templates when a deploy file sets it explicitly. In practice that means the condition reads as *"was `assets.mode` explicitly set to `development`"*, which is true only for the local dev deploy files (`deploy.dev.yml`, `deploy.dev.multi-region.yml`). Everything else — CI and deployed environments — leaves `assets` undefined there, the guard evaluates false, and the existing `expires 7d` block is emitted verbatim.

Worth being explicit about one wrinkle, since it looks like a contradiction: `deploy.bash.twig` applies its own `{{ assets['mode'] | default('development') }}`, so the generated `deploy` script can export `SPRYKER_ASSETS_MODE="development"` for a CI config that never sets it. That default is local to the bash template and does not reach the nginx templates, so it does not widen this guard. I confirmed the distinction by rendering a CI config with a temporary probe in the template, which printed `PROBE_MODE=[UNDEFINED] PROBE_DEFINED=[no]`.

Gating on `project['environment']` instead would have been wrong: real AWS deploy files also use `environment: docker.dev` and would have had their asset caching silently disabled.

## Verification

Tested on `b2b-demo-marketplace` across Yves, Back Office and Merchant Portal. Each render below is from a clean regeneration — `docker/sdk bootstrap` is a no-op when the deployment directory is already current, so the directory was removed first to avoid reading a stale artifact.

| Deploy file | `expires 7d` | `expires -1` | |
| --- | --- | --- | --- |
| `deploy.dev.yml` | 0 | 15 | changed |
| `.github/deploy/deploy.ci.acceptance.mariadb.cypress.yml` | 16 | 0 | unchanged |
| `deploy.spryker-icpplus.yml` | 14 | 0 | unchanged |

- **HTTP level** — unchanged asset → `304 Not Modified`; rebuilt asset → `200` with a new ETag and the new bytes delivered, both from the same conditional request a normal reload makes.
- **Real browser (Chrome)** — a rebuilt stylesheet is applied after a plain `location.reload()`, with a non-zero `transferSize` confirming an actual revalidation rather than a silent cache hit. Before the change the same resource reported `transferSize: 0` (served from cache, no request).
- **CI** — unaffected, per the table above. The Cypress suite contains no cache-header assertions, and its `cy.reload()` calls are all session/state driven (MFA, job-run polling, locale switch, session timeout), so none depend on asset caching. Local Cypress runs against a dev deploy file do inherit `no-cache`; that only removes a stale-asset failure mode, at the cost of a 304 per asset.

Note for anyone reproducing the CI numbers on macOS: the CI deploy files list only `linux` under `docker.mount.native.platforms`, so the generator aborts with *"Mount mode cannot be determined for `macos`"*. I rendered them by adding `macos` to a throwaway copy.

## Not covered

- Cache entries stored *before* this change keep their original 7-day freshness, so an asset already in the browser cache still needs one hard reload (or a cache clear). New entries behave correctly.
- The Cypress suite itself was not executed — the reasoning above is from the rendered configs and a grep of the specs.

Draft: I have not added a changelog entry or checked whether you'd prefer this keyed off a different flag — happy to adjust.
